### PR TITLE
feat: Supabase schema for agents and projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
@@ -30,6 +33,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitest/coverage-v8": "^4.1.0",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "jsdom": "^28.1.0",

--- a/src/lib/__tests__/database.types.test.ts
+++ b/src/lib/__tests__/database.types.test.ts
@@ -76,8 +76,8 @@ describe('Database types — agent_activity_logs table', () => {
   })
 
   it('Row has nullable metadata jsonb field', () => {
-    // metadata is a JSON object — can be null
-    type _Test = AgentActivityLogRow['metadata'] extends object | null ? true : never
+    // metadata is Json | null — Json can be string, number, boolean, object, array, or null
+    type _Test = AgentActivityLogRow['metadata'] extends import('../database.types').Json | null ? true : never
     const check: true = true as _Test
     expect(check).toBe(true)
   })

--- a/src/lib/__tests__/database.types.test.ts
+++ b/src/lib/__tests__/database.types.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest'
+import type { Database } from '../database.types'
+import { readFileSync, readdirSync } from 'fs'
+import { resolve } from 'path'
+
+// Type-level tests: these ensure the type definitions have the correct shape
+type AgentRow = Database['public']['Tables']['agents']['Row']
+type AgentInsert = Database['public']['Tables']['agents']['Insert']
+type AgentActivityLogRow = Database['public']['Tables']['agent_activity_logs']['Row']
+type ProjectRow = Database['public']['Tables']['projects']['Row']
+
+describe('Database types — agents table', () => {
+  it('Row has required uuid fields', () => {
+    type _Test = AgentRow['id'] extends string ? true : never
+    const check: true = true as _Test
+    expect(check).toBe(true)
+  })
+
+  it('Row has name and role fields', () => {
+    type _Test = AgentRow['name'] extends string ? true : never
+    const check: true = true as _Test
+    expect(check).toBe(true)
+  })
+
+  it('Row has type field constrained to valid values', () => {
+    type _Test = AgentRow['type'] extends string ? true : never
+    const check: true = true as _Test
+    expect(check).toBe(true)
+  })
+
+  it('Row has nullable optional fields', () => {
+    type _Test = AgentRow['avatar_url'] extends string | null ? true : never
+    const check: true = true as _Test
+    expect(check).toBe(true)
+  })
+
+  it('Row has status field', () => {
+    type _Test = AgentRow['status'] extends string ? true : never
+    const check: true = true as _Test
+    expect(check).toBe(true)
+  })
+
+  it('Row has timestamps', () => {
+    type _TestCreated = AgentRow['created_at'] extends string ? true : never
+    type _TestUpdated = AgentRow['updated_at'] extends string ? true : never
+    const c: true = true as _TestCreated
+    const u: true = true as _TestUpdated
+    expect(c).toBe(true)
+    expect(u).toBe(true)
+  })
+
+  it('Insert omits auto-generated fields', () => {
+    type _Test = AgentInsert['name'] extends string ? true : never
+    const check: true = true as _Test
+    expect(check).toBe(true)
+  })
+})
+
+describe('Database types — agent_activity_logs table', () => {
+  it('Row has id and agent_id', () => {
+    type _TestId = AgentActivityLogRow['id'] extends string ? true : never
+    type _TestAgentId = AgentActivityLogRow['agent_id'] extends string ? true : never
+    const id: true = true as _TestId
+    const agentId: true = true as _TestAgentId
+    expect(id).toBe(true)
+    expect(agentId).toBe(true)
+  })
+
+  it('Row has event_type and description', () => {
+    type _TestEvent = AgentActivityLogRow['event_type'] extends string ? true : never
+    type _TestDesc = AgentActivityLogRow['description'] extends string ? true : never
+    const e: true = true as _TestEvent
+    const d: true = true as _TestDesc
+    expect(e).toBe(true)
+    expect(d).toBe(true)
+  })
+
+  it('Row has nullable metadata jsonb field', () => {
+    // metadata is a JSON object — can be null
+    type _Test = AgentActivityLogRow['metadata'] extends object | null ? true : never
+    const check: true = true as _Test
+    expect(check).toBe(true)
+  })
+
+  it('Row has created_at timestamp', () => {
+    type _Test = AgentActivityLogRow['created_at'] extends string ? true : never
+    const check: true = true as _Test
+    expect(check).toBe(true)
+  })
+})
+
+describe('Database types — projects table', () => {
+  it('Row has id and project_id', () => {
+    type _TestId = ProjectRow['id'] extends string ? true : never
+    type _TestProjectId = ProjectRow['project_id'] extends string ? true : never
+    const id: true = true as _TestId
+    const pid: true = true as _TestProjectId
+    expect(id).toBe(true)
+    expect(pid).toBe(true)
+  })
+
+  it('Row has name, repo, stack, status fields', () => {
+    type _T1 = ProjectRow['name'] extends string ? true : never
+    type _T2 = ProjectRow['repo'] extends string ? true : never
+    type _T3 = ProjectRow['stack'] extends string ? true : never
+    type _T4 = ProjectRow['status'] extends string ? true : never
+    const t1: true = true as _T1
+    const t2: true = true as _T2
+    const t3: true = true as _T3
+    const t4: true = true as _T4
+    expect(t1).toBe(true)
+    expect(t2).toBe(true)
+    expect(t3).toBe(true)
+    expect(t4).toBe(true)
+  })
+
+  it('Row has nullable URL fields', () => {
+    type _T1 = ProjectRow['production_url'] extends string | null ? true : never
+    type _T2 = ProjectRow['staging_url'] extends string | null ? true : never
+    const t1: true = true as _T1
+    const t2: true = true as _T2
+    expect(t1).toBe(true)
+    expect(t2).toBe(true)
+  })
+
+  it('Row has issue count fields with number type', () => {
+    type _T1 = ProjectRow['open_issues_count'] extends number ? true : never
+    type _T2 = ProjectRow['p0_count'] extends number ? true : never
+    const t1: true = true as _T1
+    const t2: true = true as _T2
+    expect(t1).toBe(true)
+    expect(t2).toBe(true)
+  })
+
+  it('Row has timestamps', () => {
+    type _T1 = ProjectRow['created_at'] extends string ? true : never
+    type _T2 = ProjectRow['updated_at'] extends string ? true : never
+    const t1: true = true as _T1
+    const t2: true = true as _T2
+    expect(t1).toBe(true)
+    expect(t2).toBe(true)
+  })
+})
+
+describe('SQL migration files exist', () => {
+  const migrationsDir = resolve(__dirname, '../../../supabase/migrations')
+
+  it('initial schema migration file exists', () => {
+    const files = (() => {
+      try {
+        return readdirSync(migrationsDir) as string[]
+      } catch {
+        return []
+      }
+    })()
+    const hasSchema = files.some((f: string) => f.includes('initial_schema'))
+    expect(hasSchema).toBe(true)
+  })
+
+  it('migration file contains agents table creation', () => {
+    const files = readdirSync(migrationsDir) as string[]
+    const schemaFile = files.find((f: string) => f.includes('initial_schema'))
+    expect(schemaFile).toBeDefined()
+    const content = readFileSync(resolve(migrationsDir, schemaFile!), 'utf-8')
+    expect(content).toContain('CREATE TABLE')
+    expect(content).toContain('agents')
+    expect(content).toContain('agent_activity_logs')
+    expect(content).toContain('projects')
+  })
+
+  it('migration file enables RLS on all tables', () => {
+    const files = readdirSync(migrationsDir) as string[]
+    const schemaFile = files.find((f: string) => f.includes('initial_schema'))!
+    const content = readFileSync(resolve(migrationsDir, schemaFile), 'utf-8')
+    expect(content).toContain('ENABLE ROW LEVEL SECURITY')
+    // All three tables should have RLS
+    const rlsMatches = (content.match(/ENABLE ROW LEVEL SECURITY/g) || []).length
+    expect(rlsMatches).toBeGreaterThanOrEqual(3)
+  })
+
+  it('migration file creates anon read policy', () => {
+    const files = readdirSync(migrationsDir) as string[]
+    const schemaFile = files.find((f: string) => f.includes('initial_schema'))!
+    const content = readFileSync(resolve(migrationsDir, schemaFile), 'utf-8')
+    expect(content).toContain('CREATE POLICY')
+    expect(content).toContain('anon')
+  })
+})
+
+describe('Seed data file exists', () => {
+  it('seed.sql file exists in supabase directory', () => {
+    const seedPath = resolve(__dirname, '../../../supabase/seed.sql')
+    const content = readFileSync(seedPath, 'utf-8')
+    expect(content.length).toBeGreaterThan(0)
+  })
+
+  it('seed data includes known agents', () => {
+    const seedPath = resolve(__dirname, '../../../supabase/seed.sql')
+    const content = readFileSync(seedPath, 'utf-8')
+    // Should include the known agent names from the issue
+    expect(content).toContain('Scout')
+    expect(content).toContain('Forge')
+  })
+
+  it('seed data includes project entries', () => {
+    const seedPath = resolve(__dirname, '../../../supabase/seed.sql')
+    const content = readFileSync(seedPath, 'utf-8')
+    expect(content).toContain('ios-dennis-system')
+    expect(content).toContain('myagentdashboard')
+  })
+})

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -1,0 +1,143 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export interface Database {
+  public: {
+    Tables: {
+      agents: {
+        Row: {
+          id: string
+          name: string
+          type: string
+          role: string
+          description: string
+          systems: string[]
+          interaction_guide: string
+          avatar_url: string | null
+          status: string
+          current_task: string | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          name: string
+          type: string
+          role: string
+          description: string
+          systems?: string[]
+          interaction_guide?: string
+          avatar_url?: string | null
+          status?: string
+          current_task?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          name?: string
+          type?: string
+          role?: string
+          description?: string
+          systems?: string[]
+          interaction_guide?: string
+          avatar_url?: string | null
+          status?: string
+          current_task?: string | null
+          updated_at?: string
+        }
+      }
+      agent_activity_logs: {
+        Row: {
+          id: string
+          agent_id: string
+          event_type: string
+          description: string
+          metadata: Json | null
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          agent_id: string
+          event_type: string
+          description: string
+          metadata?: Json | null
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          agent_id?: string
+          event_type?: string
+          description?: string
+          metadata?: Json | null
+        }
+      }
+      projects: {
+        Row: {
+          id: string
+          project_id: string
+          name: string
+          repo: string
+          stack: string
+          status: string
+          hosting: string
+          production_url: string | null
+          staging_url: string | null
+          slack_channel_id: string
+          open_issues_count: number
+          p0_count: number
+          p1_count: number
+          p2_count: number
+          p3_count: number
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          project_id: string
+          name: string
+          repo: string
+          stack: string
+          status?: string
+          hosting: string
+          production_url?: string | null
+          staging_url?: string | null
+          slack_channel_id: string
+          open_issues_count?: number
+          p0_count?: number
+          p1_count?: number
+          p2_count?: number
+          p3_count?: number
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          project_id?: string
+          name?: string
+          repo?: string
+          stack?: string
+          status?: string
+          hosting?: string
+          production_url?: string | null
+          staging_url?: string | null
+          slack_channel_id?: string
+          open_issues_count?: number
+          p0_count?: number
+          p1_count?: number
+          p2_count?: number
+          p3_count?: number
+          updated_at?: string
+        }
+      }
+    }
+    Views: Record<string, never>
+    Functions: Record<string, never>
+    Enums: Record<string, never>
+  }
+}

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -6,6 +6,10 @@ export type Json =
   | { [key: string]: Json | undefined }
   | Json[]
 
+export type AgentType = 'openclaw' | 'claude-code'
+export type AgentStatus = 'active' | 'idle' | 'offline'
+export type ProjectStatus = 'active' | 'inactive'
+
 export interface Database {
   public: {
     Tables: {
@@ -13,13 +17,13 @@ export interface Database {
         Row: {
           id: string
           name: string
-          type: string
+          type: AgentType
           role: string
           description: string
           systems: string[]
           interaction_guide: string
           avatar_url: string | null
-          status: string
+          status: AgentStatus
           current_task: string | null
           created_at: string
           updated_at: string
@@ -27,13 +31,13 @@ export interface Database {
         Insert: {
           id?: string
           name: string
-          type: string
+          type: AgentType
           role: string
           description: string
           systems?: string[]
           interaction_guide?: string
           avatar_url?: string | null
-          status?: string
+          status?: AgentStatus
           current_task?: string | null
           created_at?: string
           updated_at?: string
@@ -41,13 +45,13 @@ export interface Database {
         Update: {
           id?: string
           name?: string
-          type?: string
+          type?: AgentType
           role?: string
           description?: string
           systems?: string[]
           interaction_guide?: string
           avatar_url?: string | null
-          status?: string
+          status?: AgentStatus
           current_task?: string | null
           updated_at?: string
         }
@@ -84,7 +88,7 @@ export interface Database {
           name: string
           repo: string
           stack: string
-          status: string
+          status: ProjectStatus
           hosting: string
           production_url: string | null
           staging_url: string | null
@@ -103,7 +107,7 @@ export interface Database {
           name: string
           repo: string
           stack: string
-          status?: string
+          status?: ProjectStatus
           hosting: string
           production_url?: string | null
           staging_url?: string | null
@@ -122,7 +126,7 @@ export interface Database {
           name?: string
           repo?: string
           stack?: string
-          status?: string
+          status?: ProjectStatus
           hosting?: string
           production_url?: string | null
           staging_url?: string | null

--- a/supabase/migrations/20260315000000_initial_schema.sql
+++ b/supabase/migrations/20260315000000_initial_schema.sql
@@ -1,0 +1,101 @@
+-- Initial schema for Agent Dashboard
+-- Creates agents, agent_activity_logs, and projects tables with RLS
+
+-- ============================================================
+-- agents table
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.agents (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name             text NOT NULL,
+  type             text NOT NULL CHECK (type IN ('openclaw', 'claude-code')),
+  role             text NOT NULL,
+  description      text NOT NULL DEFAULT '',
+  systems          text[] NOT NULL DEFAULT '{}',
+  interaction_guide text NOT NULL DEFAULT '',
+  avatar_url       text,
+  status           text NOT NULL DEFAULT 'offline' CHECK (status IN ('active', 'idle', 'offline')),
+  current_task     text,
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.agents ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "anon_read_agents"
+  ON public.agents
+  FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+-- ============================================================
+-- agent_activity_logs table
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.agent_activity_logs (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id    uuid NOT NULL REFERENCES public.agents(id) ON DELETE CASCADE,
+  event_type  text NOT NULL,
+  description text NOT NULL DEFAULT '',
+  metadata    jsonb,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_agent_activity_logs_agent_id ON public.agent_activity_logs(agent_id);
+CREATE INDEX idx_agent_activity_logs_created_at ON public.agent_activity_logs(created_at DESC);
+
+ALTER TABLE public.agent_activity_logs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "anon_read_agent_activity_logs"
+  ON public.agent_activity_logs
+  FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+-- ============================================================
+-- projects table
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.projects (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id         text NOT NULL UNIQUE,
+  name               text NOT NULL,
+  repo               text NOT NULL,
+  stack              text NOT NULL,
+  status             text NOT NULL DEFAULT 'inactive' CHECK (status IN ('active', 'inactive')),
+  hosting            text NOT NULL DEFAULT '',
+  production_url     text,
+  staging_url        text,
+  slack_channel_id   text NOT NULL DEFAULT '',
+  open_issues_count  int NOT NULL DEFAULT 0,
+  p0_count           int NOT NULL DEFAULT 0,
+  p1_count           int NOT NULL DEFAULT 0,
+  p2_count           int NOT NULL DEFAULT 0,
+  p3_count           int NOT NULL DEFAULT 0,
+  created_at         timestamptz NOT NULL DEFAULT now(),
+  updated_at         timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.projects ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "anon_read_projects"
+  ON public.projects
+  FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+-- ============================================================
+-- updated_at trigger helper
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER set_agents_updated_at
+  BEFORE UPDATE ON public.agents
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TRIGGER set_projects_updated_at
+  BEFORE UPDATE ON public.projects
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();

--- a/supabase/migrations/20260315000000_initial_schema.sql
+++ b/supabase/migrations/20260315000000_initial_schema.sql
@@ -27,6 +27,15 @@ CREATE POLICY "anon_read_agents"
   TO anon, authenticated
   USING (true);
 
+-- Writes are performed by backend workers using the service_role key only.
+-- The anon and authenticated roles are intentionally read-only.
+CREATE POLICY "service_role_write_agents"
+  ON public.agents
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
 -- ============================================================
 -- agent_activity_logs table
 -- ============================================================
@@ -50,6 +59,13 @@ CREATE POLICY "anon_read_agent_activity_logs"
   TO anon, authenticated
   USING (true);
 
+CREATE POLICY "service_role_write_agent_activity_logs"
+  ON public.agent_activity_logs
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
 -- ============================================================
 -- projects table
 -- ============================================================
@@ -64,11 +80,11 @@ CREATE TABLE IF NOT EXISTS public.projects (
   production_url     text,
   staging_url        text,
   slack_channel_id   text NOT NULL DEFAULT '',
-  open_issues_count  int NOT NULL DEFAULT 0,
-  p0_count           int NOT NULL DEFAULT 0,
-  p1_count           int NOT NULL DEFAULT 0,
-  p2_count           int NOT NULL DEFAULT 0,
-  p3_count           int NOT NULL DEFAULT 0,
+  open_issues_count  int NOT NULL DEFAULT 0 CHECK (open_issues_count >= 0),
+  p0_count           int NOT NULL DEFAULT 0 CHECK (p0_count >= 0),
+  p1_count           int NOT NULL DEFAULT 0 CHECK (p1_count >= 0),
+  p2_count           int NOT NULL DEFAULT 0 CHECK (p2_count >= 0),
+  p3_count           int NOT NULL DEFAULT 0 CHECK (p3_count >= 0),
   created_at         timestamptz NOT NULL DEFAULT now(),
   updated_at         timestamptz NOT NULL DEFAULT now()
 );
@@ -80,6 +96,13 @@ CREATE POLICY "anon_read_projects"
   FOR SELECT
   TO anon, authenticated
   USING (true);
+
+CREATE POLICY "service_role_write_projects"
+  ON public.projects
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
 
 -- ============================================================
 -- updated_at trigger helper

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,92 @@
+-- Seed data for Agent Dashboard
+-- Agents and projects from the Dennis Agent System
+
+-- ============================================================
+-- Agents
+-- ============================================================
+INSERT INTO public.agents (name, type, role, description, systems, interaction_guide, status)
+VALUES
+  (
+    'Scout',
+    'openclaw',
+    'Research & Discovery',
+    'Researches GitHub issues, discovers patterns, and gathers intelligence to inform implementation plans.',
+    ARRAY['GitHub', 'Exa', 'Web Search'],
+    'Assign issues or ask Scout to research a topic. Scout returns findings as structured summaries.',
+    'idle'
+  ),
+  (
+    'PM',
+    'openclaw',
+    'Product Manager',
+    'Manages the product backlog, writes and refines GitHub issues, and prioritizes work across projects.',
+    ARRAY['GitHub', 'Slack', 'projects.json'],
+    'Ask PM to create, update, or prioritize issues. PM keeps the backlog healthy and actionable.',
+    'idle'
+  ),
+  (
+    'Coach',
+    'openclaw',
+    'Quality & Review',
+    'Reviews code quality, tests coverage, and architectural decisions. Coaches the team on best practices.',
+    ARRAY['GitHub PRs', 'Vitest', 'ESLint'],
+    'Tag Coach on PRs or ask for a code review. Coach provides CRITICAL/HIGH/MEDIUM severity feedback.',
+    'idle'
+  ),
+  (
+    'Forge',
+    'openclaw',
+    'Identity & Soul',
+    'Maintains agent identity, manages the SOUL.md and IDENTITY.md files, and ensures agents stay aligned with Dennis''s vision.',
+    ARRAY['AgentsSync', 'SOUL.md', 'IDENTITY.md'],
+    'Ask Forge to update agent identity files or reflect on mission alignment.',
+    'idle'
+  ),
+  (
+    'Claude Code Builder',
+    'claude-code',
+    'Code Builder',
+    'Implements GitHub issues using TDD: writes failing tests first, then implements, then reviews and opens PRs.',
+    ARRAY['GitHub', 'Vitest', 'Playwright', 'Supabase', 'Vercel'],
+    'Assign GitHub issues to weppneragents-droid. Claude Code Builder picks them up automatically and opens PRs.',
+    'active'
+  )
+ON CONFLICT DO NOTHING;
+
+-- ============================================================
+-- Projects (from projects.json)
+-- ============================================================
+INSERT INTO public.projects (project_id, name, repo, stack, status, hosting, production_url, staging_url, slack_channel_id)
+VALUES
+  (
+    'ios-dennis-system',
+    'iOS Dennis System',
+    'dweppner/ios-dennis-system',
+    'ios',
+    'active',
+    'testflight',
+    NULL,
+    NULL,
+    'C0AMH5YRB5E'
+  ),
+  (
+    'myagentdashboard',
+    'Agent Dashboard',
+    'dweppner/myAgentDashboard',
+    'nextjs',
+    'active',
+    'vercel',
+    'https://my-agent-dashboard-sepia.vercel.app',
+    'https://my-agent-dashboard-sepia.vercel.app',
+    'C0ALGJLPF8T'
+  )
+ON CONFLICT (project_id) DO UPDATE SET
+  name = EXCLUDED.name,
+  repo = EXCLUDED.repo,
+  stack = EXCLUDED.stack,
+  status = EXCLUDED.status,
+  hosting = EXCLUDED.hosting,
+  production_url = EXCLUDED.production_url,
+  staging_url = EXCLUDED.staging_url,
+  slack_channel_id = EXCLUDED.slack_channel_id,
+  updated_at = now();

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -77,7 +77,7 @@ VALUES
     'active',
     'vercel',
     'https://my-agent-dashboard-sepia.vercel.app',
-    'https://my-agent-dashboard-sepia.vercel.app',
+    NULL,
     'C0ALGJLPF8T'
   )
 ON CONFLICT (project_id) DO UPDATE SET

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
+    },
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- Creates `agents`, `agent_activity_logs`, and `projects` tables with full column definitions
- Enables RLS on all three tables with anon read policies (dashboard is read-only)
- Adds TypeScript `Database` type definitions matching the schema
- Adds seed data for all known agents and active projects from `projects.json`

## Test Results
- 23/23 tests passing (type-level checks + migration/seed file existence)
- Lint: 0 errors (2 warnings on unused type aliases — intentional, kept for documentation)
- TypeCheck: clean
- Build: ✓

## Test Plan
- [ ] Verify migration applies cleanly to a fresh Supabase project
- [ ] Verify seed data inserts without conflicts
- [ ] Verify anon key can SELECT from all three tables
- [ ] Verify service role can INSERT/UPDATE

Closes #1