### PR TITLE
fix: resolve vitest test infrastructure for React 19 + jsdom

### DIFF
--- a/src/components/__tests__/ThemeProvider.test.tsx
+++ b/src/components/__tests__/ThemeProvider.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { ThemeProvider, useTheme } from "../ThemeProvider";
 
 function ThemeTestConsumer() {
@@ -27,13 +27,15 @@ describe("ThemeProvider", () => {
     expect(screen.getByTestId("theme-value")).toHaveTextContent("dark");
   });
 
-  it("applies dark class to documentElement by default", () => {
+  it("applies dark class to documentElement by default", async () => {
     render(
       <ThemeProvider>
         <ThemeTestConsumer />
       </ThemeProvider>
     );
-    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
+    });
   });
 
   it("restores light theme from localStorage", () => {
@@ -46,15 +48,17 @@ describe("ThemeProvider", () => {
     expect(screen.getByTestId("theme-value")).toHaveTextContent("light");
   });
 
-  it("toggles from dark to light", () => {
+  it("toggles from dark to light", async () => {
     render(
       <ThemeProvider>
         <ThemeTestConsumer />
       </ThemeProvider>
     );
     fireEvent.click(screen.getByRole("button", { name: /toggle/i }));
-    expect(screen.getByTestId("theme-value")).toHaveTextContent("light");
-    expect(document.documentElement.classList.contains("dark")).toBe(false);
+    await waitFor(() => {
+      expect(screen.getByTestId("theme-value")).toHaveTextContent("light");
+      expect(document.documentElement.classList.contains("dark")).toBe(false);
+    });
   });
 
   it("persists theme to localStorage on toggle", () => {
@@ -67,7 +71,7 @@ describe("ThemeProvider", () => {
     expect(localStorage.getItem("theme")).toBe("light");
   });
 
-  it("toggles from light back to dark", () => {
+  it("toggles from light back to dark", async () => {
     localStorage.setItem("theme", "light");
     render(
       <ThemeProvider>
@@ -75,7 +79,9 @@ describe("ThemeProvider", () => {
       </ThemeProvider>
     );
     fireEvent.click(screen.getByRole("button", { name: /toggle/i }));
-    expect(screen.getByTestId("theme-value")).toHaveTextContent("dark");
-    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    await waitFor(() => {
+      expect(screen.getByTestId("theme-value")).toHaveTextContent("dark");
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
+    });
   });
 });

--- a/src/test/mocks/next-link.tsx
+++ b/src/test/mocks/next-link.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+interface LinkProps {
+  href: string;
+  children?: React.ReactNode;
+  onClick?: () => void;
+  className?: string;
+  "aria-current"?: string | boolean;
+  [key: string]: unknown;
+}
+
+export default function Link({ href, children, ...props }: LinkProps) {
+  return <a href={href} {...props}>{children}</a>;
+}

--- a/src/test/mocks/next-navigation.ts
+++ b/src/test/mocks/next-navigation.ts
@@ -1,0 +1,14 @@
+import { vi } from 'vitest'
+
+export const usePathname = vi.fn(() => '/')
+export const useRouter = vi.fn(() => ({
+  push: vi.fn(),
+  replace: vi.fn(),
+  back: vi.fn(),
+  forward: vi.fn(),
+  refresh: vi.fn(),
+}))
+export const useSearchParams = vi.fn(() => new URLSearchParams())
+export const useParams = vi.fn(() => ({}))
+export const redirect = vi.fn()
+export const notFound = vi.fn()

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,11 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: "jsdom",
+    environmentMatchGlobs: [["src/lib/**", "node"]],
     globals: true,
+    testTimeout: 30000,
+    pool: "vmForks",
+    singleFork: true,
     setupFiles: ["./src/test/setup.ts"],
     coverage: {
       provider: "v8",
@@ -28,8 +32,19 @@ export default defineConfig({
     },
   },
   resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-    },
+    alias: [
+      { find: "@", replacement: path.resolve(__dirname, "./src") },
+      {
+        find: /^next\/link$/,
+        replacement: path.resolve(__dirname, "./src/test/mocks/next-link.tsx"),
+      },
+      {
+        find: /^next\/navigation$/,
+        replacement: path.resolve(
+          __dirname,
+          "./src/test/mocks/next-navigation.ts"
+        ),
+      },
+    ],
   },
 });


### PR DESCRIPTION
## Summary
- Fix vitest worker startup timeouts caused by React 19 + jsdom initialization being too slow
- Make component tests compatible with React 19's async state update behavior
- Add proper module mocks for Next.js internals

## Changes
- Switch vitest to vmForks pool with singleFork to avoid parallel worker timeout race conditions
- Add environmentMatchGlobs so lib tests run in faster node environment (not jsdom)
- Add next/link and next/navigation resolve aliases pointing to lightweight mock modules
- Add src/test/mocks/next-link.tsx and src/test/mocks/next-navigation.ts
- Make ThemeProvider toggle tests async with waitFor (React 19 defers useEffect updates)
- Increase testTimeout to 30000ms to handle slow jsdom startup

## Test Results
All 88 tests pass across 5 test files (previously 9 tests failed with worker timeouts).

## Context
Unblocks CI for the issue #5 navigation work (PR #9) which was merged before this fix was in place.

---
Implemented by weppneragents-droid via Dennis Agent System