### PR TITLE
feat: agent profile detail page (#3)

### DIFF
--- a/src/app/agents/[id]/page.tsx
+++ b/src/app/agents/[id]/page.tsx
@@ -1,0 +1,50 @@
+import { notFound } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { calculateAgentStats, getAdjacentAgents } from '@/lib/activity-utils'
+import { AgentProfileHeader } from '@/components/agents/agent-profile-header'
+import { AgentProfileStats } from '@/components/agents/agent-profile-stats'
+import { ActivityFeed } from '@/components/agents/activity-feed'
+
+export const dynamic = 'force-dynamic'
+
+interface PageProps {
+  params: Promise<{ id: string }>
+}
+
+export default async function AgentProfilePage({ params }: PageProps) {
+  const { id } = await params
+  const supabase = await createClient()
+
+  const [agentResult, allAgentsResult, logsResult] = await Promise.all([
+    supabase.from('agents').select('*').eq('id', id).single(),
+    supabase.from('agents').select('*').order('name'),
+    supabase
+      .from('agent_activity_logs')
+      .select('*')
+      .eq('agent_id', id)
+      .order('created_at', { ascending: false })
+      .limit(200),
+  ])
+
+  if (agentResult.error || !agentResult.data) {
+    notFound()
+  }
+
+  const agent = agentResult.data
+  const allAgents = allAgentsResult.data ?? []
+  const logs = logsResult.data ?? []
+
+  const stats = calculateAgentStats(logs)
+  const { prev, next } = getAdjacentAgents(allAgents, id)
+
+  return (
+    <div className="space-y-8 max-w-3xl">
+      <AgentProfileHeader agent={agent} prevAgent={prev} nextAgent={next} />
+      <AgentProfileStats stats={stats} />
+      <div>
+        <h2 className="text-base font-semibold text-foreground mb-3">Activity</h2>
+        <ActivityFeed logs={logs} />
+      </div>
+    </div>
+  )
+}

--- a/src/app/agents/[id]/page.tsx
+++ b/src/app/agents/[id]/page.tsx
@@ -26,11 +26,12 @@ export default async function AgentProfilePage({ params }: PageProps) {
       .limit(200),
   ])
 
-  if (agentResult.error || !agentResult.data) {
+  const agentData = agentResult.data
+  if (agentResult.error || !agentData) {
     notFound()
   }
 
-  const agent = agentResult.data
+  const agent = agentData
   const allAgents = allAgentsResult.data ?? []
   const logs = logsResult.data ?? []
 

--- a/src/components/agents/__tests__/activity-feed.test.tsx
+++ b/src/components/agents/__tests__/activity-feed.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ActivityFeed } from '../activity-feed'
+import type { ActivityLog } from '@/lib/activity-utils'
+
+function makeLog(overrides: Partial<ActivityLog> & { id?: string } = {}): ActivityLog {
+  return {
+    id: 'log-1',
+    agent_id: 'agent-1',
+    event_type: 'task_completed',
+    description: 'Finished a task',
+    metadata: null,
+    created_at: '2026-03-15T10:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeLogs(count: number, eventType = 'task_completed'): ActivityLog[] {
+  return Array.from({ length: count }, (_, i) =>
+    makeLog({ id: `log-${i}`, description: `Task ${i + 1}`, event_type: eventType })
+  )
+}
+
+describe('ActivityFeed', () => {
+  it('renders "No activity found" when logs is empty', () => {
+    render(<ActivityFeed logs={[]} />)
+    expect(screen.getByText(/no activity found/i)).toBeInTheDocument()
+  })
+
+  it('renders a log entry with description', () => {
+    render(<ActivityFeed logs={[makeLog({ description: 'Deployed app to Vercel' })]} />)
+    expect(screen.getByText('Deployed app to Vercel')).toBeInTheDocument()
+  })
+
+  it('renders event type badge', () => {
+    render(<ActivityFeed logs={[makeLog({ event_type: 'task_completed' })]} />)
+    expect(screen.getByText('Task Completed')).toBeInTheDocument()
+  })
+
+  it('renders multiple log entries', () => {
+    const logs = [
+      makeLog({ id: 'a', description: 'First task' }),
+      makeLog({ id: 'b', description: 'Second task' }),
+    ]
+    render(<ActivityFeed logs={logs} />)
+    expect(screen.getByText('First task')).toBeInTheDocument()
+    expect(screen.getByText('Second task')).toBeInTheDocument()
+  })
+
+  it('renders timestamp for each log entry', () => {
+    render(<ActivityFeed logs={[makeLog({ created_at: '2026-03-15T10:00:00Z' })]} />)
+    const timeEl = screen.getByRole('time')
+    expect(timeEl).toHaveAttribute('dateTime', '2026-03-15T10:00:00Z')
+  })
+
+  it('renders all event type filter buttons', () => {
+    render(<ActivityFeed logs={[]} />)
+    expect(screen.getByRole('button', { name: /all/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /task started/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /task completed/i })).toBeInTheDocument()
+  })
+
+  it('defaults to "all" filter active', () => {
+    render(<ActivityFeed logs={[]} />)
+    const allBtn = screen.getByRole('button', { name: /^all$/i })
+    expect(allBtn).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('shows only 20 items when more than 20 logs exist', () => {
+    const logs = makeLogs(25)
+    render(<ActivityFeed logs={logs} />)
+    // 20 entries visible
+    const items = screen.getAllByRole('listitem')
+    expect(items).toHaveLength(20)
+  })
+
+  it('shows "Load more" button when more than 20 logs exist', () => {
+    render(<ActivityFeed logs={makeLogs(25)} />)
+    expect(screen.getByRole('button', { name: /load more/i })).toBeInTheDocument()
+  })
+
+  it('does not show "Load more" when 20 or fewer logs', () => {
+    render(<ActivityFeed logs={makeLogs(20)} />)
+    expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument()
+  })
+
+  it('clicking "Load more" reveals additional items', () => {
+    const logs = makeLogs(25)
+    render(<ActivityFeed logs={logs} />)
+    fireEvent.click(screen.getByRole('button', { name: /load more/i }))
+    const items = screen.getAllByRole('listitem')
+    expect(items).toHaveLength(25)
+  })
+
+  it('filtering by event type shows only matching entries', () => {
+    const logs = [
+      makeLog({ id: 'a', event_type: 'task_completed', description: 'Task done' }),
+      makeLog({ id: 'b', event_type: 'pr_created', description: 'PR opened' }),
+    ]
+    render(<ActivityFeed logs={logs} />)
+    fireEvent.click(screen.getByRole('button', { name: /pr created/i }))
+    expect(screen.getByText('PR opened')).toBeInTheDocument()
+    expect(screen.queryByText('Task done')).not.toBeInTheDocument()
+  })
+
+  it('switching filter resets pagination to page 1', () => {
+    const logs = [
+      ...makeLogs(21, 'task_completed'),
+      makeLog({ id: 'pr-1', event_type: 'pr_created', description: 'A PR was created' }),
+    ]
+    render(<ActivityFeed logs={logs} />)
+    // Load more first page of task_completed
+    fireEvent.click(screen.getByRole('button', { name: /load more/i }))
+    // Switch to pr_created filter
+    fireEvent.click(screen.getByRole('button', { name: /pr created/i }))
+    // Should only show the one pr_created entry
+    expect(screen.getByText('A PR was created')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument()
+  })
+
+  it('switching back to "all" shows all entries', () => {
+    const logs = [
+      makeLog({ id: 'a', event_type: 'task_completed', description: 'Task done' }),
+      makeLog({ id: 'b', event_type: 'pr_created', description: 'PR opened' }),
+    ]
+    render(<ActivityFeed logs={logs} />)
+    fireEvent.click(screen.getByRole('button', { name: /pr created/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^all$/i }))
+    expect(screen.getByText('Task done')).toBeInTheDocument()
+    expect(screen.getByText('PR opened')).toBeInTheDocument()
+  })
+
+  it('shows "No activity found" when filter has no matches', () => {
+    const logs = [makeLog({ event_type: 'task_completed' })]
+    render(<ActivityFeed logs={logs} />)
+    fireEvent.click(screen.getByRole('button', { name: /pr created/i }))
+    expect(screen.getByText(/no activity found/i)).toBeInTheDocument()
+  })
+})

--- a/src/components/agents/__tests__/activity-feed.test.tsx
+++ b/src/components/agents/__tests__/activity-feed.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, within } from "@testing-library/react"
 import { ActivityFeed } from '../activity-feed'
 import type { ActivityLog } from '@/lib/activity-utils'
 
@@ -34,7 +34,8 @@ describe('ActivityFeed', () => {
 
   it('renders event type badge', () => {
     render(<ActivityFeed logs={[makeLog({ event_type: 'task_completed' })]} />)
-    expect(screen.getByText('Task Completed')).toBeInTheDocument()
+    const listItem = screen.getByRole('listitem')
+    expect(within(listItem).getByText('Task Completed')).toBeInTheDocument()
   })
 
   it('renders multiple log entries', () => {

--- a/src/components/agents/__tests__/agent-card.test.tsx
+++ b/src/components/agents/__tests__/agent-card.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { AgentCard } from '../agent-card'
+import type { Agent } from '@/types/agent'
+
+const makeAgent = (overrides: Partial<Agent> = {}): Agent => ({
+  id: 'agent-1',
+  name: 'Scout',
+  type: 'openclaw',
+  role: 'Research Agent',
+  description: 'Researches things',
+  systems: ['GitHub'],
+  interaction_guide: 'Ask Scout',
+  avatar_url: null,
+  status: 'active',
+  current_task: 'Working on issue #10',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-03-15T10:00:00Z',
+  ...overrides,
+})
+
+describe('AgentCard', () => {
+  it('renders agent name', () => {
+    render(<AgentCard agent={makeAgent()} />)
+    expect(screen.getByText('Scout')).toBeInTheDocument()
+  })
+
+  it('renders agent role', () => {
+    render(<AgentCard agent={makeAgent()} />)
+    expect(screen.getByText('Research Agent')).toBeInTheDocument()
+  })
+
+  it('renders type badge', () => {
+    render(<AgentCard agent={makeAgent()} />)
+    expect(screen.getByText('OpenClaw')).toBeInTheDocument()
+  })
+
+  it('renders status indicator', () => {
+    render(<AgentCard agent={makeAgent()} />)
+    expect(screen.getByText('Active')).toBeInTheDocument()
+  })
+
+  it('renders current task when present', () => {
+    render(<AgentCard agent={makeAgent()} />)
+    expect(screen.getByText(/Working on issue/)).toBeInTheDocument()
+  })
+
+  it('renders "No active task" when current_task is null', () => {
+    render(<AgentCard agent={makeAgent({ current_task: null })} />)
+    expect(screen.getByText(/no active task/i)).toBeInTheDocument()
+  })
+
+  it('renders a link to the agent profile page', () => {
+    render(<AgentCard agent={makeAgent({ id: 'agent-42' })} />)
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', '/agents/agent-42')
+  })
+
+  it('renders avatar fallback initial when no avatar_url', () => {
+    render(<AgentCard agent={makeAgent({ avatar_url: null })} />)
+    expect(screen.getByText('S')).toBeInTheDocument()
+  })
+
+  it('renders avatar image when avatar_url is provided', () => {
+    render(<AgentCard agent={makeAgent({ avatar_url: 'https://example.com/img.png' })} />)
+    expect(screen.getByRole('img', { name: 'Scout' })).toBeInTheDocument()
+  })
+})

--- a/src/components/agents/__tests__/agent-profile-header.test.tsx
+++ b/src/components/agents/__tests__/agent-profile-header.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { AgentProfileHeader } from '../agent-profile-header'
+import type { Agent } from '@/types/agent'
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/agents/agent-1',
+}))
+
+const makeAgent = (overrides: Partial<Agent> = {}): Agent => ({
+  id: 'agent-1',
+  name: 'Issue Worker',
+  type: 'claude-code',
+  role: 'GitHub Issue Implementer',
+  description: 'Implements GitHub issues using TDD.',
+  systems: ['GitHub', 'Slack', 'Supabase'],
+  interaction_guide: 'Assign GitHub issues to weppneragents-droid.',
+  avatar_url: null,
+  status: 'active',
+  current_task: 'Working on issue #3',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-03-15T10:00:00Z',
+  ...overrides,
+})
+
+describe('AgentProfileHeader', () => {
+  it('renders agent name', () => {
+    render(<AgentProfileHeader agent={makeAgent()} prevAgent={null} nextAgent={null} />)
+    expect(screen.getByRole('heading', { name: 'Issue Worker' })).toBeInTheDocument()
+  })
+
+  it('renders role title', () => {
+    render(<AgentProfileHeader agent={makeAgent()} prevAgent={null} nextAgent={null} />)
+    expect(screen.getByText('GitHub Issue Implementer')).toBeInTheDocument()
+  })
+
+  it('renders type badge for claude-code', () => {
+    render(<AgentProfileHeader agent={makeAgent({ type: 'claude-code' })} prevAgent={null} nextAgent={null} />)
+    expect(screen.getByText('Claude Code')).toBeInTheDocument()
+  })
+
+  it('renders type badge for openclaw', () => {
+    render(<AgentProfileHeader agent={makeAgent({ type: 'openclaw' })} prevAgent={null} nextAgent={null} />)
+    expect(screen.getByText('OpenClaw')).toBeInTheDocument()
+  })
+
+  it('renders status badge', () => {
+    render(<AgentProfileHeader agent={makeAgent({ status: 'active' })} prevAgent={null} nextAgent={null} />)
+    expect(screen.getByText('Active')).toBeInTheDocument()
+  })
+
+  it('renders idle status', () => {
+    render(<AgentProfileHeader agent={makeAgent({ status: 'idle' })} prevAgent={null} nextAgent={null} />)
+    expect(screen.getByText('Idle')).toBeInTheDocument()
+  })
+
+  it('renders offline status', () => {
+    render(<AgentProfileHeader agent={makeAgent({ status: 'offline' })} prevAgent={null} nextAgent={null} />)
+    expect(screen.getByText('Offline')).toBeInTheDocument()
+  })
+
+  it('renders description', () => {
+    render(<AgentProfileHeader agent={makeAgent()} prevAgent={null} nextAgent={null} />)
+    expect(screen.getByText('Implements GitHub issues using TDD.')).toBeInTheDocument()
+  })
+
+  it('renders systems as badges', () => {
+    render(<AgentProfileHeader agent={makeAgent()} prevAgent={null} nextAgent={null} />)
+    expect(screen.getByText('GitHub')).toBeInTheDocument()
+    expect(screen.getByText('Slack')).toBeInTheDocument()
+    expect(screen.getByText('Supabase')).toBeInTheDocument()
+  })
+
+  it('renders interaction guide', () => {
+    render(<AgentProfileHeader agent={makeAgent()} prevAgent={null} nextAgent={null} />)
+    expect(screen.getByText('Assign GitHub issues to weppneragents-droid.')).toBeInTheDocument()
+  })
+
+  it('renders avatar initials when no avatar_url', () => {
+    render(<AgentProfileHeader agent={makeAgent({ avatar_url: null })} prevAgent={null} nextAgent={null} />)
+    expect(screen.getByText('I')).toBeInTheDocument() // first letter of "Issue Worker"
+  })
+
+  it('renders avatar image when avatar_url is provided', () => {
+    render(
+      <AgentProfileHeader
+        agent={makeAgent({ avatar_url: 'https://example.com/avatar.png' })}
+        prevAgent={null}
+        nextAgent={null}
+      />
+    )
+    expect(screen.getByRole('img', { name: 'Issue Worker' })).toBeInTheDocument()
+  })
+
+  it('renders back to dashboard link', () => {
+    render(<AgentProfileHeader agent={makeAgent()} prevAgent={null} nextAgent={null} />)
+    expect(screen.getByRole('link', { name: /back/i })).toHaveAttribute('href', '/')
+  })
+
+  it('renders prev agent link when prevAgent is provided', () => {
+    const prev = makeAgent({ id: 'agent-0', name: 'Prev Agent' })
+    render(<AgentProfileHeader agent={makeAgent()} prevAgent={prev} nextAgent={null} />)
+    const link = screen.getByRole('link', { name: /prev agent/i })
+    expect(link).toHaveAttribute('href', '/agents/agent-0')
+  })
+
+  it('renders next agent link when nextAgent is provided', () => {
+    const next = makeAgent({ id: 'agent-2', name: 'Next Agent' })
+    render(<AgentProfileHeader agent={makeAgent()} prevAgent={null} nextAgent={next} />)
+    const link = screen.getByRole('link', { name: /next agent/i })
+    expect(link).toHaveAttribute('href', '/agents/agent-2')
+  })
+
+  it('does not render prev link when prevAgent is null', () => {
+    render(<AgentProfileHeader agent={makeAgent()} prevAgent={null} nextAgent={null} />)
+    expect(screen.queryByRole('link', { name: /prev agent/i })).not.toBeInTheDocument()
+  })
+
+  it('does not render next link when nextAgent is null', () => {
+    render(<AgentProfileHeader agent={makeAgent()} prevAgent={null} nextAgent={null} />)
+    expect(screen.queryByRole('link', { name: /next agent/i })).not.toBeInTheDocument()
+  })
+})

--- a/src/components/agents/__tests__/agent-profile-header.test.tsx
+++ b/src/components/agents/__tests__/agent-profile-header.test.tsx
@@ -1,7 +1,14 @@
 import { describe, it, expect } from 'vitest'
+import { createElement } from 'react'
+import type React from 'react'
 import { render, screen } from '@testing-library/react'
 import { AgentProfileHeader } from '../agent-profile-header'
 import type { Agent } from '@/types/agent'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: Record<string, unknown>) =>
+    createElement('a', { href, ...props }, children as React.ReactNode),
+}))
 
 vi.mock('next/navigation', () => ({
   usePathname: () => '/agents/agent-1',

--- a/src/components/agents/__tests__/agent-profile-stats.test.tsx
+++ b/src/components/agents/__tests__/agent-profile-stats.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { AgentProfileStats } from '../agent-profile-stats'
+import type { AgentStats } from '@/lib/activity-utils'
+
+const makeStats = (overrides: Partial<AgentStats> = {}): AgentStats => ({
+  tasks_completed_7d: 5,
+  tasks_completed_30d: 18,
+  total_tokens: 123456,
+  current_streak: 3,
+  ...overrides,
+})
+
+describe('AgentProfileStats', () => {
+  it('renders tasks completed in 7 days', () => {
+    render(<AgentProfileStats stats={makeStats({ tasks_completed_7d: 7 })} />)
+    expect(screen.getByText('7')).toBeInTheDocument()
+  })
+
+  it('renders tasks completed in 30 days', () => {
+    render(<AgentProfileStats stats={makeStats({ tasks_completed_30d: 20 })} />)
+    expect(screen.getByText('20')).toBeInTheDocument()
+  })
+
+  it('renders current streak', () => {
+    render(<AgentProfileStats stats={makeStats({ current_streak: 4 })} />)
+    expect(screen.getByText('4')).toBeInTheDocument()
+  })
+
+  it('renders total tokens', () => {
+    render(<AgentProfileStats stats={makeStats({ total_tokens: 100000 })} />)
+    // Should render formatted token count
+    expect(screen.getByText(/100[,.]?000|100k/i)).toBeInTheDocument()
+  })
+
+  it('renders streak label', () => {
+    render(<AgentProfileStats stats={makeStats()} />)
+    expect(screen.getByText(/streak/i)).toBeInTheDocument()
+  })
+
+  it('renders zero state gracefully', () => {
+    render(
+      <AgentProfileStats
+        stats={makeStats({ tasks_completed_7d: 0, tasks_completed_30d: 0, current_streak: 0, total_tokens: 0 })}
+      />
+    )
+    const zeros = screen.getAllByText('0')
+    expect(zeros.length).toBeGreaterThanOrEqual(3)
+  })
+})

--- a/src/components/agents/activity-feed.tsx
+++ b/src/components/agents/activity-feed.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { useState } from 'react'
+import { cn } from '@/lib/utils'
+import { formatEventType, getEventTypeBadgeColor } from '@/lib/activity-utils'
+import type { ActivityLog } from '@/lib/activity-utils'
+
+const PAGE_SIZE = 20
+
+const EVENT_TYPE_OPTIONS = [
+  'all',
+  'task_started',
+  'task_completed',
+  'pr_created',
+  'issue_opened',
+  'deployment',
+]
+
+interface ActivityFeedProps {
+  logs: ActivityLog[]
+}
+
+export function ActivityFeed({ logs }: ActivityFeedProps) {
+  const [filterType, setFilterType] = useState<string>('all')
+  const [page, setPage] = useState(1)
+
+  const filtered =
+    filterType === 'all' ? logs : logs.filter((l) => l.event_type === filterType)
+
+  const visible = filtered.slice(0, page * PAGE_SIZE)
+  const hasMore = visible.length < filtered.length
+
+  function handleFilterChange(type: string) {
+    setFilterType(type)
+    setPage(1)
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Filter bar */}
+      <div className="flex flex-wrap gap-2" role="group" aria-label="Filter by event type">
+        {EVENT_TYPE_OPTIONS.map((type) => (
+          <button
+            key={type}
+            onClick={() => handleFilterChange(type)}
+            aria-pressed={filterType === type}
+            className={cn(
+              'rounded-full px-3 py-1 text-xs font-medium transition-colors',
+              filterType === type
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-secondary text-secondary-foreground hover:bg-secondary/80'
+            )}
+          >
+            {type === 'all' ? 'All' : formatEventType(type)}
+          </button>
+        ))}
+      </div>
+
+      {/* Log entries */}
+      {visible.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-4">No activity found.</p>
+      ) : (
+        <ol className="space-y-3">
+          {visible.map((log) => (
+            <li
+              key={log.id}
+              className="flex gap-3 rounded-lg border border-border bg-card p-3 text-sm"
+            >
+              <div className="flex flex-col gap-1 min-w-0 flex-1">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span
+                    className={cn(
+                      'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+                      getEventTypeBadgeColor(log.event_type)
+                    )}
+                  >
+                    {formatEventType(log.event_type)}
+                  </span>
+                  <time
+                    dateTime={log.created_at}
+                    className="text-xs text-muted-foreground"
+                  >
+                    {new Date(log.created_at).toLocaleString()}
+                  </time>
+                </div>
+                <p className="text-foreground">{log.description}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+
+      {/* Load more */}
+      {hasMore && (
+        <button
+          onClick={() => setPage((p) => p + 1)}
+          className="w-full rounded-md border border-border py-2 text-sm text-muted-foreground hover:bg-accent transition-colors"
+        >
+          Load more ({filtered.length - visible.length} remaining)
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/components/agents/agent-card.tsx
+++ b/src/components/agents/agent-card.tsx
@@ -1,13 +1,9 @@
 'use client'
 
+import Link from 'next/link'
 import { cn } from '@/lib/utils'
-import { getStatusColor, getStatusDotColor, getStatusLabel, truncateTask } from '@/lib/agent-utils'
+import { getStatusColor, getStatusDotColor, getStatusLabel, getTypeLabel, truncateTask } from '@/lib/agent-utils'
 import type { Agent } from '@/types/agent'
-
-const TYPE_LABELS: Record<string, string> = {
-  openclaw: 'OpenClaw',
-  'claude-code': 'Claude Code',
-}
 
 const TASK_MAX_LENGTH = 60
 
@@ -20,11 +16,14 @@ export function AgentCard({ agent }: AgentCardProps) {
   const dotColor = getStatusDotColor(agent.status)
   const statusLabel = getStatusLabel(agent.status)
   const taskDisplay = truncateTask(agent.current_task, TASK_MAX_LENGTH)
-  const typeLabel = TYPE_LABELS[agent.type] ?? agent.type
+  const typeLabel = getTypeLabel(agent.type)
   const lastActive = new Date(agent.updated_at).toLocaleString()
 
   return (
-    <div className="rounded-xl border border-border bg-card p-4 shadow-sm flex flex-col gap-3">
+    <Link
+      href={`/agents/${agent.id}`}
+      className="rounded-xl border border-border bg-card p-4 shadow-sm flex flex-col gap-3 hover:border-primary/50 transition-colors"
+    >
       {/* Header: avatar + name + type badge */}
       <div className="flex items-start gap-3">
         <div className="flex-shrink-0 size-10 rounded-full bg-muted flex items-center justify-center overflow-hidden">
@@ -86,6 +85,6 @@ export function AgentCard({ agent }: AgentCardProps) {
       <p className="text-xs text-muted-foreground/50 mt-auto">
         Last active: {lastActive}
       </p>
-    </div>
+    </Link>
   )
 }

--- a/src/components/agents/agent-profile-header.tsx
+++ b/src/components/agents/agent-profile-header.tsx
@@ -1,0 +1,133 @@
+import Link from 'next/link'
+import { cn } from '@/lib/utils'
+import {
+  getStatusColor,
+  getStatusDotColor,
+  getStatusLabel,
+  getTypeLabel,
+} from '@/lib/agent-utils'
+import type { Agent } from '@/types/agent'
+
+interface AgentProfileHeaderProps {
+  agent: Agent
+  prevAgent: Agent | null
+  nextAgent: Agent | null
+}
+
+export function AgentProfileHeader({ agent, prevAgent, nextAgent }: AgentProfileHeaderProps) {
+  const statusColor = getStatusColor(agent.status)
+  const dotColor = getStatusDotColor(agent.status)
+  const statusLabel = getStatusLabel(agent.status)
+  const typeLabel = getTypeLabel(agent.type)
+
+  return (
+    <div className="space-y-6">
+      {/* Navigation row */}
+      <nav className="flex items-center justify-between flex-wrap gap-2" aria-label="Agent navigation">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          aria-label="Back to dashboard"
+        >
+          ← Back
+        </Link>
+        <div className="flex items-center gap-3">
+          {prevAgent && (
+            <Link
+              href={`/agents/${prevAgent.id}`}
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              aria-label={`Prev agent: ${prevAgent.name}`}
+            >
+              ← {prevAgent.name}
+            </Link>
+          )}
+          {nextAgent && (
+            <Link
+              href={`/agents/${nextAgent.id}`}
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              aria-label={`Next agent: ${nextAgent.name}`}
+            >
+              {nextAgent.name} →
+            </Link>
+          )}
+        </div>
+      </nav>
+
+      {/* Profile header card */}
+      <div className="rounded-xl border border-border bg-card p-6 space-y-4">
+        {/* Avatar + name + badges */}
+        <div className="flex items-start gap-4 flex-wrap">
+          <div className="flex-shrink-0 size-16 rounded-full bg-muted flex items-center justify-center overflow-hidden">
+            {agent.avatar_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={agent.avatar_url}
+                alt={agent.name}
+                className="size-16 object-cover"
+              />
+            ) : (
+              <span className="text-2xl font-bold text-muted-foreground select-none">
+                {agent.name.charAt(0).toUpperCase()}
+              </span>
+            )}
+          </div>
+
+          <div className="flex-1 min-w-0 space-y-1">
+            <div className="flex items-center gap-2 flex-wrap">
+              <h1 className="text-2xl font-bold text-foreground">{agent.name}</h1>
+              <span
+                className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium bg-secondary text-secondary-foreground"
+              >
+                {typeLabel}
+              </span>
+            </div>
+            <p className="text-sm text-muted-foreground">{agent.role}</p>
+            <div className="flex items-center gap-2">
+              <span
+                className={cn('inline-block size-2 rounded-full flex-shrink-0', dotColor)}
+                aria-hidden="true"
+              />
+              <span
+                className={cn(
+                  'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+                  statusColor
+                )}
+              >
+                {statusLabel}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* About section */}
+        <div className="space-y-4 pt-2 border-t border-border">
+          <div>
+            <h2 className="text-sm font-semibold text-foreground mb-1">About</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">{agent.description}</p>
+          </div>
+
+          {agent.systems.length > 0 && (
+            <div>
+              <h2 className="text-sm font-semibold text-foreground mb-2">Systems</h2>
+              <div className="flex flex-wrap gap-2">
+                {agent.systems.map((system) => (
+                  <span
+                    key={system}
+                    className="inline-flex items-center rounded-md px-2.5 py-0.5 text-xs font-medium border border-border bg-muted text-muted-foreground"
+                  >
+                    {system}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div>
+            <h2 className="text-sm font-semibold text-foreground mb-1">How to interact</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">{agent.interaction_guide}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/agents/agent-profile-stats.tsx
+++ b/src/components/agents/agent-profile-stats.tsx
@@ -1,0 +1,57 @@
+import type { AgentStats } from '@/lib/activity-utils'
+
+interface AgentProfileStatsProps {
+  stats: AgentStats
+}
+
+function formatTokens(count: number): string {
+  if (count >= 1_000_000) return `${parseFloat((count / 1_000_000).toFixed(1))}M`
+  if (count >= 1_000) return `${parseFloat((count / 1_000).toFixed(1))}k`
+  return String(count)
+}
+
+interface StatCardProps {
+  value: string | number
+  label: string
+  sublabel?: string
+}
+
+function StatCard({ value, label, sublabel }: StatCardProps) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 text-center space-y-1">
+      <p className="text-2xl font-bold text-foreground tabular-nums">{value}</p>
+      <p className="text-xs font-medium text-muted-foreground">{label}</p>
+      {sublabel && <p className="text-xs text-muted-foreground/60">{sublabel}</p>}
+    </div>
+  )
+}
+
+export function AgentProfileStats({ stats }: AgentProfileStatsProps) {
+  return (
+    <div>
+      <h2 className="text-base font-semibold text-foreground mb-3">Stats</h2>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <StatCard
+          value={stats.tasks_completed_7d}
+          label="Tasks Completed"
+          sublabel="Last 7 days"
+        />
+        <StatCard
+          value={stats.tasks_completed_30d}
+          label="Tasks Completed"
+          sublabel="Last 30 days"
+        />
+        <StatCard
+          value={stats.current_streak}
+          label="Day Streak"
+          sublabel="Consecutive days active"
+        />
+        <StatCard
+          value={formatTokens(stats.total_tokens)}
+          label="Total Tokens"
+          sublabel="All time"
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/lib/__tests__/activity-utils.test.ts
+++ b/src/lib/__tests__/activity-utils.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from 'vitest'
+import {
+  formatEventType,
+  getEventTypeBadgeColor,
+  calculateAgentStats,
+  getAdjacentAgents,
+  extractTokensFromMetadata,
+} from '../activity-utils'
+import type { Agent } from '@/types/agent'
+import type { Database } from '@/lib/database.types'
+
+type ActivityLog = Database['public']['Tables']['agent_activity_logs']['Row']
+
+const makeAgent = (overrides: Partial<Agent> = {}): Agent => ({
+  id: 'agent-1',
+  name: 'Test Agent',
+  type: 'openclaw',
+  role: 'Tester',
+  description: 'A test agent',
+  systems: ['GitHub', 'Slack'],
+  interaction_guide: 'Just ask',
+  avatar_url: null,
+  status: 'active',
+  current_task: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  ...overrides,
+})
+
+const makeLog = (
+  overrides: Partial<ActivityLog> & { created_at?: string } = {}
+): ActivityLog => ({
+  id: 'log-1',
+  agent_id: 'agent-1',
+  event_type: 'task_completed',
+  description: 'Finished a task',
+  metadata: null,
+  created_at: new Date().toISOString(),
+  ...overrides,
+})
+
+// --- formatEventType ---
+
+describe('formatEventType', () => {
+  it('formats task_started as Task Started', () => {
+    expect(formatEventType('task_started')).toBe('Task Started')
+  })
+
+  it('formats task_completed as Task Completed', () => {
+    expect(formatEventType('task_completed')).toBe('Task Completed')
+  })
+
+  it('formats pr_created as PR Created', () => {
+    expect(formatEventType('pr_created')).toBe('PR Created')
+  })
+
+  it('formats issue_opened as Issue Opened', () => {
+    expect(formatEventType('issue_opened')).toBe('Issue Opened')
+  })
+
+  it('formats deployment as Deployment', () => {
+    expect(formatEventType('deployment')).toBe('Deployment')
+  })
+
+  it('handles unknown event type by capitalizing each word', () => {
+    expect(formatEventType('some_custom_event')).toBe('Some Custom Event')
+  })
+})
+
+// --- getEventTypeBadgeColor ---
+
+describe('getEventTypeBadgeColor', () => {
+  it('returns green for task_completed', () => {
+    expect(getEventTypeBadgeColor('task_completed')).toContain('green')
+  })
+
+  it('returns blue for task_started', () => {
+    expect(getEventTypeBadgeColor('task_started')).toContain('blue')
+  })
+
+  it('returns purple for pr_created', () => {
+    expect(getEventTypeBadgeColor('pr_created')).toContain('purple')
+  })
+
+  it('returns orange for deployment', () => {
+    expect(getEventTypeBadgeColor('deployment')).toContain('orange')
+  })
+
+  it('returns a default color for unknown types', () => {
+    const color = getEventTypeBadgeColor('unknown_event')
+    expect(color).toBeTruthy()
+    expect(typeof color).toBe('string')
+  })
+})
+
+// --- extractTokensFromMetadata ---
+
+describe('extractTokensFromMetadata', () => {
+  it('returns 0 for null metadata', () => {
+    expect(extractTokensFromMetadata(null)).toBe(0)
+  })
+
+  it('returns sum of tokens_input and tokens_output', () => {
+    const metadata = { tokens_input: 100, tokens_output: 50 }
+    expect(extractTokensFromMetadata(metadata)).toBe(150)
+  })
+
+  it('returns tokens_input only when tokens_output missing', () => {
+    const metadata = { tokens_input: 200 }
+    expect(extractTokensFromMetadata(metadata)).toBe(200)
+  })
+
+  it('returns tokens_output only when tokens_input missing', () => {
+    const metadata = { tokens_output: 75 }
+    expect(extractTokensFromMetadata(metadata)).toBe(75)
+  })
+
+  it('returns 0 when metadata has no token fields', () => {
+    const metadata = { some_other_field: 'value' }
+    expect(extractTokensFromMetadata(metadata)).toBe(0)
+  })
+})
+
+// --- calculateAgentStats ---
+
+describe('calculateAgentStats', () => {
+  const now = new Date()
+
+  const daysAgo = (n: number): string => {
+    const d = new Date(now)
+    d.setDate(d.getDate() - n)
+    return d.toISOString()
+  }
+
+  it('counts tasks_completed in last 7 days', () => {
+    const logs: ActivityLog[] = [
+      makeLog({ event_type: 'task_completed', created_at: daysAgo(1) }),
+      makeLog({ event_type: 'task_completed', created_at: daysAgo(3) }),
+      makeLog({ event_type: 'task_completed', created_at: daysAgo(6) }),
+      makeLog({ event_type: 'task_completed', created_at: daysAgo(8) }), // outside 7d
+    ]
+    const stats = calculateAgentStats(logs)
+    expect(stats.tasks_completed_7d).toBe(3)
+  })
+
+  it('counts tasks_completed in last 30 days', () => {
+    const logs: ActivityLog[] = [
+      makeLog({ event_type: 'task_completed', created_at: daysAgo(5) }),
+      makeLog({ event_type: 'task_completed', created_at: daysAgo(15) }),
+      makeLog({ event_type: 'task_completed', created_at: daysAgo(29) }),
+      makeLog({ event_type: 'task_completed', created_at: daysAgo(31) }), // outside 30d
+    ]
+    const stats = calculateAgentStats(logs)
+    expect(stats.tasks_completed_30d).toBe(3)
+  })
+
+  it('calculates total tokens from all logs with metadata', () => {
+    const logs: ActivityLog[] = [
+      makeLog({ metadata: { tokens_input: 100, tokens_output: 50 } }),
+      makeLog({ metadata: { tokens_input: 200, tokens_output: 100 } }),
+      makeLog({ metadata: null }),
+    ]
+    const stats = calculateAgentStats(logs)
+    expect(stats.total_tokens).toBe(450)
+  })
+
+  it('returns zero stats for empty logs array', () => {
+    const stats = calculateAgentStats([])
+    expect(stats.tasks_completed_7d).toBe(0)
+    expect(stats.tasks_completed_30d).toBe(0)
+    expect(stats.total_tokens).toBe(0)
+    expect(stats.current_streak).toBe(0)
+  })
+
+  it('only counts task_completed events (not other types)', () => {
+    const logs: ActivityLog[] = [
+      makeLog({ event_type: 'task_started', created_at: daysAgo(1) }),
+      makeLog({ event_type: 'task_completed', created_at: daysAgo(2) }),
+      makeLog({ event_type: 'pr_created', created_at: daysAgo(3) }),
+    ]
+    const stats = calculateAgentStats(logs)
+    expect(stats.tasks_completed_7d).toBe(1)
+  })
+
+  it('computes current_streak as consecutive days with any activity', () => {
+    // Today + yesterday + day before = streak of 3
+    const logs: ActivityLog[] = [
+      makeLog({ created_at: daysAgo(0) }),
+      makeLog({ created_at: daysAgo(1) }),
+      makeLog({ created_at: daysAgo(2) }),
+      // gap — day 4 missing
+      makeLog({ created_at: daysAgo(4) }),
+    ]
+    const stats = calculateAgentStats(logs)
+    expect(stats.current_streak).toBe(3)
+  })
+
+  it('streak is 0 when there is no activity today or yesterday', () => {
+    const logs: ActivityLog[] = [
+      makeLog({ created_at: daysAgo(3) }),
+      makeLog({ created_at: daysAgo(4) }),
+    ]
+    const stats = calculateAgentStats(logs)
+    expect(stats.current_streak).toBe(0)
+  })
+})
+
+// --- getAdjacentAgents ---
+
+describe('getAdjacentAgents', () => {
+  const agents: Agent[] = [
+    makeAgent({ id: 'a1', name: 'Agent A' }),
+    makeAgent({ id: 'a2', name: 'Agent B' }),
+    makeAgent({ id: 'a3', name: 'Agent C' }),
+  ]
+
+  it('returns prev and next agents for a middle agent', () => {
+    const { prev, next } = getAdjacentAgents(agents, 'a2')
+    expect(prev?.id).toBe('a1')
+    expect(next?.id).toBe('a3')
+  })
+
+  it('returns null for prev when agent is first', () => {
+    const { prev, next } = getAdjacentAgents(agents, 'a1')
+    expect(prev).toBeNull()
+    expect(next?.id).toBe('a2')
+  })
+
+  it('returns null for next when agent is last', () => {
+    const { prev, next } = getAdjacentAgents(agents, 'a3')
+    expect(prev?.id).toBe('a2')
+    expect(next).toBeNull()
+  })
+
+  it('returns null for both when agent id not found', () => {
+    const { prev, next } = getAdjacentAgents(agents, 'unknown')
+    expect(prev).toBeNull()
+    expect(next).toBeNull()
+  })
+
+  it('handles single agent list', () => {
+    const single = [makeAgent({ id: 'solo' })]
+    const { prev, next } = getAdjacentAgents(single, 'solo')
+    expect(prev).toBeNull()
+    expect(next).toBeNull()
+  })
+})

--- a/src/lib/__tests__/agent-utils.test.ts
+++ b/src/lib/__tests__/agent-utils.test.ts
@@ -3,6 +3,7 @@ import {
   getStatusColor,
   getStatusDotColor,
   getStatusLabel,
+  getTypeLabel,
   truncateTask,
   getAgentStatusSummary,
 } from '../agent-utils'
@@ -59,6 +60,20 @@ describe('getStatusLabel', () => {
 
   it('returns capitalized label for unknown status', () => {
     expect(getStatusLabel('busy')).toBe('Busy')
+  })
+})
+
+describe('getTypeLabel', () => {
+  it('returns "Claude Code" for claude-code type', () => {
+    expect(getTypeLabel('claude-code')).toBe('Claude Code')
+  })
+
+  it('returns "OpenClaw" for openclaw type', () => {
+    expect(getTypeLabel('openclaw')).toBe('OpenClaw')
+  })
+
+  it('returns the raw type for unknown types', () => {
+    expect(getTypeLabel('custom-bot')).toBe('custom-bot')
   })
 })
 

--- a/src/lib/activity-utils.ts
+++ b/src/lib/activity-utils.ts
@@ -1,0 +1,117 @@
+import type { Database } from './database.types'
+import type { Agent } from '@/types/agent'
+
+export type ActivityLog = Database['public']['Tables']['agent_activity_logs']['Row']
+
+export interface AgentStats {
+  tasks_completed_7d: number
+  tasks_completed_30d: number
+  total_tokens: number
+  current_streak: number
+}
+
+const EVENT_TYPE_LABELS: Record<string, string> = {
+  task_started: 'Task Started',
+  task_completed: 'Task Completed',
+  pr_created: 'PR Created',
+  issue_opened: 'Issue Opened',
+  deployment: 'Deployment',
+}
+
+const EVENT_TYPE_COLORS: Record<string, string> = {
+  task_completed: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300',
+  task_started: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300',
+  pr_created: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300',
+  deployment: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300',
+  issue_opened: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300',
+}
+
+export function formatEventType(type: string): string {
+  if (type in EVENT_TYPE_LABELS) return EVENT_TYPE_LABELS[type]
+  return type
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+export function getEventTypeBadgeColor(type: string): string {
+  return EVENT_TYPE_COLORS[type] ?? 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300'
+}
+
+export function extractTokensFromMetadata(metadata: unknown): number {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return 0
+  const m = metadata as Record<string, unknown>
+  const input = typeof m.tokens_input === 'number' ? m.tokens_input : 0
+  const output = typeof m.tokens_output === 'number' ? m.tokens_output : 0
+  return input + output
+}
+
+export function calculateAgentStats(logs: ActivityLog[]): AgentStats {
+  if (logs.length === 0) {
+    return { tasks_completed_7d: 0, tasks_completed_30d: 0, total_tokens: 0, current_streak: 0 }
+  }
+
+  const now = new Date()
+  const sevenDaysAgo = new Date(now)
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7)
+  const thirtyDaysAgo = new Date(now)
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
+
+  let tasks_completed_7d = 0
+  let tasks_completed_30d = 0
+  let total_tokens = 0
+
+  for (const log of logs) {
+    const createdAt = new Date(log.created_at)
+    if (log.event_type === 'task_completed') {
+      if (createdAt >= sevenDaysAgo) tasks_completed_7d++
+      if (createdAt >= thirtyDaysAgo) tasks_completed_30d++
+    }
+    total_tokens += extractTokensFromMetadata(log.metadata)
+  }
+
+  const current_streak = calculateStreak(logs)
+
+  return { tasks_completed_7d, tasks_completed_30d, total_tokens, current_streak }
+}
+
+function calculateStreak(logs: ActivityLog[]): number {
+  const activeDays = new Set(
+    logs.map((log) => log.created_at.split('T')[0])
+  )
+
+  const now = new Date()
+  const todayStr = now.toISOString().split('T')[0]
+  const yesterday = new Date(now)
+  yesterday.setDate(yesterday.getDate() - 1)
+  const yesterdayStr = yesterday.toISOString().split('T')[0]
+
+  if (!activeDays.has(todayStr) && !activeDays.has(yesterdayStr)) return 0
+
+  let streak = 0
+  const cursor = new Date(now)
+
+  while (true) {
+    const dateStr = cursor.toISOString().split('T')[0]
+    if (activeDays.has(dateStr)) {
+      streak++
+      cursor.setDate(cursor.getDate() - 1)
+    } else {
+      break
+    }
+  }
+
+  return streak
+}
+
+export function getAdjacentAgents(
+  agents: Agent[],
+  currentId: string
+): { prev: Agent | null; next: Agent | null } {
+  const idx = agents.findIndex((a) => a.id === currentId)
+  if (idx === -1) return { prev: null, next: null }
+  return {
+    prev: idx > 0 ? agents[idx - 1] : null,
+    next: idx < agents.length - 1 ? agents[idx + 1] : null,
+  }
+}

--- a/src/lib/agent-utils.ts
+++ b/src/lib/agent-utils.ts
@@ -1,5 +1,14 @@
 import type { Agent, AgentStatusSummary } from '@/types/agent'
 
+const TYPE_LABELS: Record<string, string> = {
+  openclaw: 'OpenClaw',
+  'claude-code': 'Claude Code',
+}
+
+export function getTypeLabel(type: string): string {
+  return TYPE_LABELS[type] ?? type
+}
+
 export function getStatusColor(status: string): string {
   switch (status) {
     case 'active':

--- a/src/test/mocks/next-link.tsx
+++ b/src/test/mocks/next-link.tsx
@@ -1,14 +1,14 @@
-import React from "react";
+import React from 'react'
 
-interface LinkProps {
-  href: string;
-  children?: React.ReactNode;
-  onClick?: () => void;
-  className?: string;
-  "aria-current"?: string | boolean;
-  [key: string]: unknown;
+interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  href: string
+  children?: React.ReactNode
 }
 
-export default function Link({ href, children, ...props }: LinkProps) {
-  return <a href={href} {...props}>{children}</a>;
-}
+const Link = ({ href, children, ...props }: LinkProps) => (
+  <a href={href} {...props}>
+    {children}
+  </a>
+)
+
+export default Link

--- a/src/test/mocks/next-navigation.ts
+++ b/src/test/mocks/next-navigation.ts
@@ -1,14 +1,4 @@
-import { vi } from 'vitest'
-
-export const usePathname = vi.fn(() => '/')
-export const useRouter = vi.fn(() => ({
-  push: vi.fn(),
-  replace: vi.fn(),
-  back: vi.fn(),
-  forward: vi.fn(),
-  refresh: vi.fn(),
-}))
-export const useSearchParams = vi.fn(() => new URLSearchParams())
-export const useParams = vi.fn(() => ({}))
-export const redirect = vi.fn()
-export const notFound = vi.fn()
+export const usePathname = () => '/'
+export const useRouter = () => ({ push: () => {}, replace: () => {}, back: () => {} })
+export const useSearchParams = () => new URLSearchParams()
+export const useParams = () => ({})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     globals: true,
     pool: "vmForks",
     singleFork: true,
-    testTimeout: 30000,
+    testTimeout: 120000,
     setupFiles: ["./src/test/setup.ts"],
     coverage: {
       provider: "v8",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,9 +8,9 @@ export default defineConfig({
     environment: "jsdom",
     environmentMatchGlobs: [["src/lib/**", "node"]],
     globals: true,
-    testTimeout: 30000,
     pool: "vmForks",
     singleFork: true,
+    testTimeout: 30000,
     setupFiles: ["./src/test/setup.ts"],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Summary

Agent profile page at `/agents/[id]` with full profile layout, activity feed, stats, and prev/next agent navigation.

## Changes
- `src/app/agents/[id]/page.tsx` — server component, parallel data fetching, 404 via notFound()
- `AgentProfileHeader` — avatar/initials, name, type badge, status indicator, role, description, systems tags, interaction guide, prev/next agent links, back-to-dashboard link
- `AgentProfileStats` — tasks completed (7d/30d), current streak, total tokens used
- `ActivityFeed` — paginated (20/page), filterable by event type, load more, empty state
- `agent-card.tsx` — wrapped in Link to navigate to agent profile
- `src/lib/activity-utils.ts` — calculateAgentStats, getAdjacentAgents, formatEventType, getEventTypeBadgeColor, extractTokensFromMetadata
- Test fixes: next/link mock, within() scoping, vitest timeout bump to 120s
- TypeScript narrowing fix: extract agentData variable before notFound() guard

## Test Results
- TypeScript: 0 errors
- Vitest: 105+ tests passing, 0 failures
- Note: `pnpm run lint` and `pnpm run build` blocked by macOS maxfiles=256 ENFILE system issue (not a code issue)

## Closes
Closes #3

---
Implemented by weppneragents-droid via Dennis Agent System