### PR TITLE
feat: token usage tracking and display (#6)

### DIFF
--- a/src/app/agents/[id]/page.tsx
+++ b/src/app/agents/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { calculateAgentStats, getAdjacentAgents } from '@/lib/activity-utils'
+import { buildTokenChartProps, TokenUsageChart } from '@/components/agents/token-usage-chart'
 import { AgentProfileHeader } from '@/components/agents/agent-profile-header'
 import { AgentProfileStats } from '@/components/agents/agent-profile-stats'
 import { ActivityFeed } from '@/components/agents/activity-feed'
@@ -37,11 +38,18 @@ export default async function AgentProfilePage({ params }: PageProps) {
 
   const stats = calculateAgentStats(logs)
   const { prev, next } = getAdjacentAgents(allAgents, id)
+  const tokenChartProps = buildTokenChartProps(logs)
 
   return (
     <div className="space-y-8 max-w-3xl">
       <AgentProfileHeader agent={agent} prevAgent={prev} nextAgent={next} />
       <AgentProfileStats stats={stats} />
+      <div>
+        <h2 className="text-base font-semibold text-foreground mb-3">Token Usage</h2>
+        <div className="rounded-lg border border-border bg-card p-4">
+          <TokenUsageChart {...tokenChartProps} />
+        </div>
+      </div>
       <div>
         <h2 className="text-base font-semibold text-foreground mb-3">Activity</h2>
         <ActivityFeed logs={logs} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,60 @@
 import { createClient } from '@/lib/supabase/server'
 import { AgentGrid } from '@/components/agents/agent-grid'
+import { TokenSummary } from '@/components/home/token-summary'
+import { computeTodayTokenSummary } from '@/lib/token-utils'
+import { extractTokensFromMetadata } from '@/lib/activity-utils'
+import type { Database } from '@/lib/database.types'
+
+type AgentRow = Database['public']['Tables']['agents']['Row']
+type ActivityLogRow = Database['public']['Tables']['agent_activity_logs']['Row']
 
 export const dynamic = 'force-dynamic'
 
 export default async function Home() {
   const supabase = await createClient()
 
-  const { data: agents, error } = await supabase
+  const todayStart = new Date()
+  todayStart.setHours(0, 0, 0, 0)
+
+  const { data: agents, error: agentsError } = (await supabase
     .from('agents')
     .select('*')
-    .order('name')
+    .order('name')) as { data: AgentRow[] | null; error: { message: string } | null }
 
-  if (error) {
-    console.error('Failed to fetch agents:', error.message)
+  const { data: todayLogs } = (await supabase
+    .from('agent_activity_logs')
+    .select('*')
+    .gte('created_at', todayStart.toISOString())) as { data: ActivityLogRow[] | null; error: unknown }
+
+  if (agentsError) {
+    console.error('Failed to fetch agents:', agentsError.message)
   }
 
-  return <AgentGrid initialAgents={agents ?? []} />
+  // Aggregate today's tokens per agent
+  const tokensByAgent = new Map<string, number>()
+  for (const log of todayLogs ?? []) {
+    const tokens = extractTokensFromMetadata(log.metadata)
+    tokensByAgent.set(log.agent_id, (tokensByAgent.get(log.agent_id) ?? 0) + tokens)
+  }
+
+  const agentTokenInput = (agents ?? []).map((a) => ({
+    name: a.name,
+    tokens: tokensByAgent.get(a.id) ?? 0,
+  }))
+
+  const tokenSummary = computeTodayTokenSummary(agentTokenInput)
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-base font-semibold text-foreground mb-3">Today&apos;s Token Usage</h2>
+        <TokenSummary
+          totalTokensToday={tokenSummary.totalTokens}
+          topConsumerName={tokenSummary.topConsumerName}
+          topConsumerTokens={tokenSummary.topConsumerTokens}
+        />
+      </div>
+      <AgentGrid initialAgents={agents ?? []} />
+    </div>
+  )
 }

--- a/src/components/agents/__tests__/token-usage-chart.test.tsx
+++ b/src/components/agents/__tests__/token-usage-chart.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { TokenUsageChart } from '../token-usage-chart'
+import type { DailyTokens } from '@/lib/token-utils'
+
+const makeDailyTokens = (date: string, total = 0): DailyTokens => ({
+  date,
+  tokens_input: Math.floor(total * 0.7),
+  tokens_output: Math.floor(total * 0.3),
+  total,
+})
+
+const mockData7d: DailyTokens[] = Array.from({ length: 7 }, (_, i) => {
+  const d = new Date()
+  d.setDate(d.getDate() - (6 - i))
+  return makeDailyTokens(d.toISOString().split('T')[0], i * 1000)
+})
+
+const mockData30d: DailyTokens[] = Array.from({ length: 30 }, (_, i) => {
+  const d = new Date()
+  d.setDate(d.getDate() - (29 - i))
+  return makeDailyTokens(d.toISOString().split('T')[0], i * 500)
+})
+
+describe('TokenUsageChart', () => {
+  it('renders without crashing', () => {
+    render(<TokenUsageChart data7d={mockData7d} data30d={mockData30d} />)
+    expect(screen.getByRole('figure')).toBeInTheDocument()
+  })
+
+  it('shows period toggle buttons', () => {
+    render(<TokenUsageChart data7d={mockData7d} data30d={mockData30d} />)
+    expect(screen.getByRole('button', { name: /7d/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /30d/i })).toBeInTheDocument()
+  })
+
+  it('defaults to 7d period', () => {
+    render(<TokenUsageChart data7d={mockData7d} data30d={mockData30d} />)
+    const btn7d = screen.getByRole('button', { name: /7d/i })
+    expect(btn7d).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('switches to 30d when clicking the 30d button', () => {
+    render(<TokenUsageChart data7d={mockData7d} data30d={mockData30d} />)
+    const btn30d = screen.getByRole('button', { name: /30d/i })
+    fireEvent.click(btn30d)
+    expect(btn30d).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: /7d/i })).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('displays total tokens and cost estimate', () => {
+    render(<TokenUsageChart data7d={mockData7d} data30d={mockData30d} costPerMillion={3} />)
+    expect(screen.getByText(/total/i)).toBeInTheDocument()
+    expect(screen.getByText(/\$/)).toBeInTheDocument()
+  })
+
+  it('renders an SVG chart', () => {
+    const { container } = render(
+      <TokenUsageChart data7d={mockData7d} data30d={mockData30d} />
+    )
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders with all-zero data without crashing', () => {
+    const zeroData = Array.from({ length: 7 }, (_, i) => {
+      const d = new Date()
+      d.setDate(d.getDate() - (6 - i))
+      return makeDailyTokens(d.toISOString().split('T')[0], 0)
+    })
+    render(<TokenUsageChart data7d={zeroData} data30d={zeroData} />)
+    expect(screen.getByRole('figure')).toBeInTheDocument()
+  })
+
+  it('accepts custom costPerMillion prop', () => {
+    render(<TokenUsageChart data7d={mockData7d} data30d={mockData30d} costPerMillion={15} />)
+    expect(screen.getByRole('figure')).toBeInTheDocument()
+  })
+})

--- a/src/components/agents/token-usage-chart.tsx
+++ b/src/components/agents/token-usage-chart.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import { useState } from 'react'
+import { aggregateTokensByDay, estimateTokenCost, formatCost, type DailyTokens } from '@/lib/token-utils'
+import type { Database } from '@/lib/database.types'
+
+type ActivityLog = Database['public']['Tables']['agent_activity_logs']['Row']
+
+type Period = '7d' | '30d'
+
+interface TokenUsageChartProps {
+  /** Pre-aggregated 7-day data */
+  data7d: DailyTokens[]
+  /** Pre-aggregated 30-day data */
+  data30d: DailyTokens[]
+  costPerMillion?: number
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${parseFloat((n / 1_000_000).toFixed(1))}M`
+  if (n >= 1_000) return `${parseFloat((n / 1_000).toFixed(1))}k`
+  return String(n)
+}
+
+function BarChart({ data }: { data: DailyTokens[] }) {
+  const maxTotal = Math.max(...data.map((d) => d.total), 1)
+  const chartHeight = 80
+  const barWidth = 8
+  const gap = 4
+  const totalWidth = data.length * (barWidth + gap) - gap
+
+  return (
+    <svg
+      width={totalWidth}
+      height={chartHeight}
+      viewBox={`0 0 ${totalWidth} ${chartHeight}`}
+      aria-hidden="true"
+      className="w-full"
+      style={{ maxWidth: totalWidth }}
+    >
+      {data.map((d, i) => {
+        const barHeight = Math.max((d.total / maxTotal) * chartHeight, d.total > 0 ? 2 : 0)
+        const inputHeight = d.total > 0
+          ? Math.round((d.tokens_input / d.total) * barHeight)
+          : 0
+        const outputHeight = barHeight - inputHeight
+        const x = i * (barWidth + gap)
+
+        return (
+          <g key={d.date}>
+            {/* output tokens (top portion) */}
+            {outputHeight > 0 && (
+              <rect
+                x={x}
+                y={chartHeight - barHeight}
+                width={barWidth}
+                height={outputHeight}
+                className="fill-primary/40"
+                rx={1}
+              />
+            )}
+            {/* input tokens (bottom portion) */}
+            {inputHeight > 0 && (
+              <rect
+                x={x}
+                y={chartHeight - inputHeight}
+                width={barWidth}
+                height={inputHeight}
+                className="fill-primary"
+                rx={1}
+              />
+            )}
+            {/* empty state bar */}
+            {d.total === 0 && (
+              <rect
+                x={x}
+                y={chartHeight - 2}
+                width={barWidth}
+                height={2}
+                className="fill-muted"
+                rx={1}
+              />
+            )}
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+export function TokenUsageChart({ data7d, data30d, costPerMillion = 3 }: TokenUsageChartProps) {
+  const [period, setPeriod] = useState<Period>('7d')
+
+  const data = period === '7d' ? data7d : data30d
+  const totalTokens = data.reduce((sum, d) => sum + d.total, 0)
+  const cost = estimateTokenCost(totalTokens, costPerMillion)
+
+  return (
+    <figure className="space-y-3" aria-label="Token usage chart">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-xs text-muted-foreground">Total</p>
+          <p className="text-lg font-bold tabular-nums text-foreground">
+            {formatTokens(totalTokens)}
+          </p>
+          <p className="text-xs text-muted-foreground">{formatCost(cost)} est.</p>
+        </div>
+
+        <div className="flex gap-1" role="group" aria-label="Period selector">
+          {(['7d', '30d'] as const).map((p) => (
+            <button
+              key={p}
+              onClick={() => setPeriod(p)}
+              aria-pressed={period === p}
+              className={[
+                'px-2 py-1 text-xs rounded font-medium transition-colors',
+                period === p
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-muted text-muted-foreground hover:bg-muted/80',
+              ].join(' ')}
+            >
+              {p}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="overflow-hidden">
+        <BarChart data={data} />
+      </div>
+
+      <div className="flex items-center gap-3 text-xs text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-2 h-2 rounded-sm bg-primary" />
+          Input
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-2 h-2 rounded-sm bg-primary/40" />
+          Output
+        </span>
+      </div>
+    </figure>
+  )
+}
+
+/** Server-side helper to pre-aggregate logs for the chart props */
+export function buildTokenChartProps(logs: ActivityLog[], costPerMillion = 3) {
+  return {
+    data7d: aggregateTokensByDay(logs, 7),
+    data30d: aggregateTokensByDay(logs, 30),
+    costPerMillion,
+  }
+}

--- a/src/components/home/__tests__/token-summary.test.tsx
+++ b/src/components/home/__tests__/token-summary.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TokenSummary } from '../token-summary'
+
+describe('TokenSummary', () => {
+  it('renders without crashing', () => {
+    render(
+      <TokenSummary totalTokensToday={0} topConsumerName={null} topConsumerTokens={0} />
+    )
+    expect(screen.getByText(/tokens today/i)).toBeInTheDocument()
+  })
+
+  it('displays formatted total tokens today', () => {
+    render(
+      <TokenSummary totalTokensToday={12345} topConsumerName="Forge" topConsumerTokens={10000} />
+    )
+    expect(screen.getByText(/12\.3k/i)).toBeInTheDocument()
+  })
+
+  it('displays top consumer name when provided', () => {
+    render(
+      <TokenSummary totalTokensToday={5000} topConsumerName="Scout" topConsumerTokens={4000} />
+    )
+    expect(screen.getByText(/Scout/)).toBeInTheDocument()
+  })
+
+  it('shows a dash or fallback when no top consumer', () => {
+    render(
+      <TokenSummary totalTokensToday={0} topConsumerName={null} topConsumerTokens={0} />
+    )
+    expect(screen.getByText(/—|none|no agent/i)).toBeInTheDocument()
+  })
+
+  it('displays zero tokens as 0', () => {
+    render(
+      <TokenSummary totalTokensToday={0} topConsumerName={null} topConsumerTokens={0} />
+    )
+    expect(screen.getByText('0')).toBeInTheDocument()
+  })
+
+  it('formats large numbers with M suffix', () => {
+    render(
+      <TokenSummary
+        totalTokensToday={2_500_000}
+        topConsumerName="Forge"
+        topConsumerTokens={1_000_000}
+      />
+    )
+    expect(screen.getByText(/2\.5M/i)).toBeInTheDocument()
+  })
+})

--- a/src/components/home/token-summary.tsx
+++ b/src/components/home/token-summary.tsx
@@ -1,0 +1,42 @@
+interface TokenSummaryProps {
+  totalTokensToday: number
+  topConsumerName: string | null
+  topConsumerTokens: number
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${parseFloat((n / 1_000_000).toFixed(1))}M`
+  if (n >= 1_000) return `${parseFloat((n / 1_000).toFixed(1))}k`
+  return String(n)
+}
+
+function StatItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 space-y-1">
+      <p className="text-xs font-medium text-muted-foreground">{label}</p>
+      <p className="text-xl font-bold tabular-nums text-foreground">{value}</p>
+    </div>
+  )
+}
+
+export function TokenSummary({ totalTokensToday, topConsumerName, topConsumerTokens }: TokenSummaryProps) {
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <StatItem
+        label="Tokens Today"
+        value={formatTokens(totalTokensToday)}
+      />
+      <div className="rounded-lg border border-border bg-card p-4 space-y-1">
+        <p className="text-xs font-medium text-muted-foreground">Top Consumer</p>
+        <p className="text-xl font-bold tabular-nums text-foreground truncate">
+          {topConsumerName ?? '—'}
+        </p>
+        {topConsumerName && (
+          <p className="text-xs text-muted-foreground">
+            {formatTokens(topConsumerTokens)} tokens
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/__tests__/token-utils.test.ts
+++ b/src/lib/__tests__/token-utils.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest'
+import {
+  aggregateTokensByDay,
+  estimateTokenCost,
+  formatCost,
+  computeTodayTokenSummary,
+} from '../token-utils'
+import type { Database } from '@/lib/database.types'
+
+type ActivityLog = Database['public']['Tables']['agent_activity_logs']['Row']
+
+const makeLog = (overrides: Partial<ActivityLog> = {}): ActivityLog => ({
+  id: 'log-1',
+  agent_id: 'agent-1',
+  event_type: 'task_completed',
+  description: 'Finished a task',
+  metadata: null,
+  created_at: new Date().toISOString(),
+  ...overrides,
+})
+
+const daysAgo = (n: number): string => {
+  const d = new Date()
+  d.setDate(d.getDate() - n)
+  return d.toISOString()
+}
+
+const todayDate = (): string => new Date().toISOString().split('T')[0]
+
+// --- aggregateTokensByDay ---
+
+describe('aggregateTokensByDay', () => {
+  it('returns an array with N entries for N days', () => {
+    const result = aggregateTokensByDay([], 7)
+    expect(result).toHaveLength(7)
+  })
+
+  it('returns entries in ascending date order', () => {
+    const result = aggregateTokensByDay([], 7)
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i].date > result[i - 1].date).toBe(true)
+    }
+  })
+
+  it('fills in zeros for days with no logs', () => {
+    const result = aggregateTokensByDay([], 7)
+    for (const entry of result) {
+      expect(entry.tokens_input).toBe(0)
+      expect(entry.tokens_output).toBe(0)
+      expect(entry.total).toBe(0)
+    }
+  })
+
+  it('aggregates tokens for today correctly', () => {
+    const logs: ActivityLog[] = [
+      makeLog({ created_at: daysAgo(0), metadata: { tokens_input: 100, tokens_output: 50 } }),
+      makeLog({ created_at: daysAgo(0), metadata: { tokens_input: 200, tokens_output: 100 } }),
+    ]
+    const result = aggregateTokensByDay(logs, 7)
+    const today = result.find((d) => d.date === todayDate())
+    expect(today?.tokens_input).toBe(300)
+    expect(today?.tokens_output).toBe(150)
+    expect(today?.total).toBe(450)
+  })
+
+  it('excludes logs outside the window', () => {
+    const logs: ActivityLog[] = [
+      makeLog({ created_at: daysAgo(10), metadata: { tokens_input: 999, tokens_output: 999 } }),
+    ]
+    const result = aggregateTokensByDay(logs, 7)
+    const totalTokens = result.reduce((sum, d) => sum + d.total, 0)
+    expect(totalTokens).toBe(0)
+  })
+
+  it('handles logs with null metadata gracefully', () => {
+    const logs: ActivityLog[] = [makeLog({ created_at: daysAgo(0), metadata: null })]
+    const result = aggregateTokensByDay(logs, 7)
+    const today = result.find((d) => d.date === todayDate())
+    expect(today?.total).toBe(0)
+  })
+
+  it('handles logs with partial metadata (input only)', () => {
+    const logs: ActivityLog[] = [
+      makeLog({ created_at: daysAgo(0), metadata: { tokens_input: 500 } }),
+    ]
+    const result = aggregateTokensByDay(logs, 7)
+    const today = result.find((d) => d.date === todayDate())
+    expect(today?.tokens_input).toBe(500)
+    expect(today?.tokens_output).toBe(0)
+    expect(today?.total).toBe(500)
+  })
+
+  it('supports 30-day window', () => {
+    const result = aggregateTokensByDay([], 30)
+    expect(result).toHaveLength(30)
+  })
+
+  it('distributes logs across correct days', () => {
+    const yesterday = new Date()
+    yesterday.setDate(yesterday.getDate() - 1)
+    const yesterdayStr = yesterday.toISOString().split('T')[0]
+
+    const threeDaysAgo = new Date()
+    threeDaysAgo.setDate(threeDaysAgo.getDate() - 3)
+    const threeDaysAgoStr = threeDaysAgo.toISOString().split('T')[0]
+
+    const logs: ActivityLog[] = [
+      makeLog({ created_at: daysAgo(1), metadata: { tokens_input: 100, tokens_output: 50 } }),
+      makeLog({ created_at: daysAgo(3), metadata: { tokens_input: 200, tokens_output: 100 } }),
+    ]
+    const result = aggregateTokensByDay(logs, 7)
+    const d1 = result.find((d) => d.date === yesterdayStr)
+    const d3 = result.find((d) => d.date === threeDaysAgoStr)
+    expect(d1?.total).toBe(150)
+    expect(d3?.total).toBe(300)
+  })
+})
+
+// --- estimateTokenCost ---
+
+describe('estimateTokenCost', () => {
+  it('calculates cost at default rate ($3/million)', () => {
+    expect(estimateTokenCost(1_000_000)).toBeCloseTo(3.0)
+  })
+
+  it('calculates cost at custom rate', () => {
+    expect(estimateTokenCost(500_000, 10.0)).toBeCloseTo(5.0)
+  })
+
+  it('returns 0 for 0 tokens', () => {
+    expect(estimateTokenCost(0)).toBe(0)
+  })
+
+  it('handles fractional results', () => {
+    expect(estimateTokenCost(100, 3.0)).toBeCloseTo(0.0003)
+  })
+})
+
+// --- formatCost ---
+
+describe('formatCost', () => {
+  it('formats zero as $0.00', () => {
+    expect(formatCost(0)).toBe('$0.00')
+  })
+
+  it('formats small amounts as $0.00', () => {
+    expect(formatCost(0.001)).toBe('$0.00')
+  })
+
+  it('formats typical amounts with 2 decimal places', () => {
+    expect(formatCost(1.5)).toBe('$1.50')
+  })
+
+  it('formats larger amounts correctly', () => {
+    expect(formatCost(12.345)).toBe('$12.35')
+  })
+})
+
+// --- computeTodayTokenSummary ---
+
+describe('computeTodayTokenSummary', () => {
+  it('sums all agent tokens', () => {
+    const input = [
+      { name: 'Forge', tokens: 1000 },
+      { name: 'Scout', tokens: 2000 },
+    ]
+    const result = computeTodayTokenSummary(input)
+    expect(result.totalTokens).toBe(3000)
+  })
+
+  it('identifies top consumer', () => {
+    const input = [
+      { name: 'Forge', tokens: 1000 },
+      { name: 'Scout', tokens: 5000 },
+      { name: 'Ranger', tokens: 3000 },
+    ]
+    const result = computeTodayTokenSummary(input)
+    expect(result.topConsumerName).toBe('Scout')
+    expect(result.topConsumerTokens).toBe(5000)
+  })
+
+  it('returns null top consumer for empty input', () => {
+    const result = computeTodayTokenSummary([])
+    expect(result.topConsumerName).toBeNull()
+    expect(result.topConsumerTokens).toBe(0)
+    expect(result.totalTokens).toBe(0)
+  })
+
+  it('handles single agent', () => {
+    const input = [{ name: 'Solo', tokens: 500 }]
+    const result = computeTodayTokenSummary(input)
+    expect(result.topConsumerName).toBe('Solo')
+    expect(result.totalTokens).toBe(500)
+  })
+})

--- a/src/lib/token-utils.ts
+++ b/src/lib/token-utils.ts
@@ -1,0 +1,78 @@
+import type { Database } from '@/lib/database.types'
+
+type ActivityLog = Database['public']['Tables']['agent_activity_logs']['Row']
+
+export interface DailyTokens {
+  date: string // YYYY-MM-DD
+  tokens_input: number
+  tokens_output: number
+  total: number
+}
+
+export interface TodayTokenSummary {
+  totalTokens: number
+  topConsumerName: string | null
+  topConsumerTokens: number
+}
+
+export function aggregateTokensByDay(logs: ActivityLog[], days: number): DailyTokens[] {
+  const now = new Date()
+  const result: DailyTokens[] = []
+
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(now)
+    d.setDate(d.getDate() - i)
+    result.push({
+      date: d.toISOString().split('T')[0],
+      tokens_input: 0,
+      tokens_output: 0,
+      total: 0,
+    })
+  }
+
+  const dateSet = new Set(result.map((r) => r.date))
+
+  for (const log of logs) {
+    const dateStr = log.created_at.split('T')[0]
+    if (!dateSet.has(dateStr)) continue
+
+    const entry = result.find((r) => r.date === dateStr)
+    if (!entry) continue
+
+    const meta = log.metadata
+    if (!meta || typeof meta !== 'object' || Array.isArray(meta)) continue
+
+    const m = meta as Record<string, unknown>
+    const input = typeof m.tokens_input === 'number' ? m.tokens_input : 0
+    const output = typeof m.tokens_output === 'number' ? m.tokens_output : 0
+    entry.tokens_input += input
+    entry.tokens_output += output
+    entry.total += input + output
+  }
+
+  return result
+}
+
+export function estimateTokenCost(tokens: number, costPerMillion = 3.0): number {
+  return (tokens / 1_000_000) * costPerMillion
+}
+
+export function formatCost(cost: number): string {
+  if (cost < 0.01) return '$0.00'
+  return `$${cost.toFixed(2)}`
+}
+
+export function computeTodayTokenSummary(
+  agentTokens: { name: string; tokens: number }[]
+): TodayTokenSummary {
+  const totalTokens = agentTokens.reduce((sum, a) => sum + a.tokens, 0)
+  const top = agentTokens.reduce<{ name: string; tokens: number } | null>((best, a) => {
+    if (!best || a.tokens > best.tokens) return a
+    return best
+  }, null)
+  return {
+    totalTokens,
+    topConsumerName: top?.name ?? null,
+    topConsumerTokens: top?.tokens ?? 0,
+  }
+}


### PR DESCRIPTION
## Summary
- Adds token usage tracking across all agents with visualization components
- Displays token summary stats on the home page dashboard
- Shows per-agent token usage breakdown on agent profile pages

## Changes
- `src/lib/token-utils.ts` — Utility functions for token data aggregation
- `src/components/agents/token-usage-chart.tsx` — Bar chart showing agent token usage
- `src/components/home/token-summary.tsx` — Summary card for the home page
- `src/app/page.tsx` — Updated home page with token summary section
- `src/app/agents/[id]/page.tsx` — Updated agent profile with token chart
- Tests for all new components and utilities (35 new tests)

## Test plan
- [x] 35 new tests pass for token-utils, token-usage-chart, token-summary
- [x] All existing tests continue to pass
- [x] Lint: passed
- [x] Typecheck: passed

Closes #6