### PR TITLE
feat: global activity feed page (#7)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Generated coverage reports
+    "coverage/**",
   ]),
 ]);
 

--- a/src/app/activity/page.tsx
+++ b/src/app/activity/page.tsx
@@ -1,7 +1,6 @@
 import { createClient } from '@/lib/supabase/server'
 import { GlobalActivityFeed } from '@/components/activity/global-activity-feed'
 import type { GlobalActivityLog } from '@/lib/global-activity-utils'
-import type { Agent } from '@/types/agent'
 
 export const dynamic = 'force-dynamic'
 
@@ -14,19 +13,21 @@ export default async function ActivityPage() {
       .select('*, agents(id, name, avatar_url)')
       .order('created_at', { ascending: false })
       .limit(200),
-    supabase.from('agents').select('*').order('name'),
+    supabase.from('agents').select('id, name').order('name'),
   ])
 
   if (logsResult.error) {
-    console.error('Failed to fetch activity logs:', logsResult.error.message)
+    throw new Error(`Failed to fetch activity logs: ${logsResult.error.message}`)
   }
 
   if (agentsResult.error) {
-    console.error('Failed to fetch agents:', agentsResult.error.message)
+    throw new Error(`Failed to fetch agents: ${agentsResult.error.message}`)
   }
 
-  const logs = (logsResult.data ?? []) as GlobalActivityLog[]
-  const agents = (agentsResult.data ?? []) as Agent[]
+  // The Supabase SDK does not infer the nested join shape, so we cast to the
+  // extended type that includes the `agents` join field.
+  const logs = logsResult.data as GlobalActivityLog[]
+  const agents = agentsResult.data
 
   return <GlobalActivityFeed initialLogs={logs} agents={agents} />
 }

--- a/src/app/activity/page.tsx
+++ b/src/app/activity/page.tsx
@@ -1,0 +1,32 @@
+import { createClient } from '@/lib/supabase/server'
+import { GlobalActivityFeed } from '@/components/activity/global-activity-feed'
+import type { GlobalActivityLog } from '@/lib/global-activity-utils'
+import type { Agent } from '@/types/agent'
+
+export const dynamic = 'force-dynamic'
+
+export default async function ActivityPage() {
+  const supabase = await createClient()
+
+  const [logsResult, agentsResult] = await Promise.all([
+    supabase
+      .from('agent_activity_logs')
+      .select('*, agents(id, name, avatar_url)')
+      .order('created_at', { ascending: false })
+      .limit(200),
+    supabase.from('agents').select('*').order('name'),
+  ])
+
+  if (logsResult.error) {
+    console.error('Failed to fetch activity logs:', logsResult.error.message)
+  }
+
+  if (agentsResult.error) {
+    console.error('Failed to fetch agents:', agentsResult.error.message)
+  }
+
+  const logs = (logsResult.data ?? []) as GlobalActivityLog[]
+  const agents = (agentsResult.data ?? []) as Agent[]
+
+  return <GlobalActivityFeed initialLogs={logs} agents={agents} />
+}

--- a/src/components/activity/__tests__/global-activity-feed.test.tsx
+++ b/src/components/activity/__tests__/global-activity-feed.test.tsx
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { GlobalActivityFeed } from '../global-activity-feed'
+import type { GlobalActivityLog } from '@/lib/global-activity-utils'
+import type { Agent } from '@/types/agent'
+
+function makeLog(overrides: Partial<GlobalActivityLog> = {}): GlobalActivityLog {
+  return {
+    id: 'log-1',
+    agent_id: 'agent-1',
+    event_type: 'task_completed',
+    description: 'Finished a task',
+    metadata: null,
+    created_at: '2026-03-15T10:00:00Z',
+    agents: { id: 'agent-1', name: 'Ted Openclaw', avatar_url: null },
+    ...overrides,
+  }
+}
+
+const AGENTS: Agent[] = [
+  {
+    id: 'agent-1',
+    name: 'Ted Openclaw',
+    type: 'openclaw',
+    role: 'dispatcher',
+    description: 'Test agent',
+    systems: [],
+    interaction_guide: '',
+    avatar_url: null,
+    status: 'active',
+    current_task: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+]
+
+function makeLogs(count: number, eventType = 'task_completed'): GlobalActivityLog[] {
+  return Array.from({ length: count }, (_, i) =>
+    makeLog({ id: `log-${i}`, description: `Task ${i + 1}`, event_type: eventType })
+  )
+}
+
+describe('GlobalActivityFeed', () => {
+  it('renders "No activity found" when logs is empty', () => {
+    render(<GlobalActivityFeed initialLogs={[]} agents={[]} />)
+    expect(screen.getByText(/no activity found/i)).toBeInTheDocument()
+  })
+
+  it('renders a log entry with description', () => {
+    render(<GlobalActivityFeed initialLogs={[makeLog({ description: 'Deployed to Vercel' })]} agents={AGENTS} />)
+    expect(screen.getByText('Deployed to Vercel')).toBeInTheDocument()
+  })
+
+  it('renders event type badge', () => {
+    render(<GlobalActivityFeed initialLogs={[makeLog({ event_type: 'task_completed' })]} agents={AGENTS} />)
+    expect(screen.getByText('Task Completed')).toBeInTheDocument()
+  })
+
+  it('renders agent name linked to profile', () => {
+    render(<GlobalActivityFeed initialLogs={[makeLog()]} agents={AGENTS} />)
+    const link = screen.getByRole('link', { name: 'Ted Openclaw' })
+    expect(link).toHaveAttribute('href', '/agents/agent-1')
+  })
+
+  it('renders timestamp', () => {
+    render(<GlobalActivityFeed initialLogs={[makeLog({ created_at: '2026-03-15T10:00:00Z' })]} agents={AGENTS} />)
+    const timeEl = screen.getByRole('time')
+    expect(timeEl).toHaveAttribute('dateTime', '2026-03-15T10:00:00Z')
+  })
+
+  it('shows agent dropdown with all agents option', () => {
+    render(<GlobalActivityFeed initialLogs={[makeLog()]} agents={AGENTS} />)
+    expect(screen.getByRole('combobox')).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'All agents' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Ted Openclaw' })).toBeInTheDocument()
+  })
+
+  it('filters by agent', () => {
+    const logs = [
+      makeLog({ id: 'a', agent_id: 'agent-1', description: 'Ted task', agents: { id: 'agent-1', name: 'Ted Openclaw', avatar_url: null } }),
+      makeLog({ id: 'b', agent_id: 'agent-2', description: 'Other task', agents: { id: 'agent-2', name: 'Other Agent', avatar_url: null } }),
+    ]
+    render(<GlobalActivityFeed initialLogs={logs} agents={AGENTS} />)
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'agent-1' } })
+    expect(screen.getByText('Ted task')).toBeInTheDocument()
+    expect(screen.queryByText('Other task')).not.toBeInTheDocument()
+  })
+
+  it('shows all event type filter buttons', () => {
+    render(<GlobalActivityFeed initialLogs={[]} agents={[]} />)
+    expect(screen.getByRole('button', { name: /^all$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /task started/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /task completed/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /pr created/i })).toBeInTheDocument()
+  })
+
+  it('shows date range filter buttons', () => {
+    render(<GlobalActivityFeed initialLogs={[]} agents={[]} />)
+    expect(screen.getByRole('button', { name: /all time/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /today/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /7 days/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /30 days/i })).toBeInTheDocument()
+  })
+
+  it('filters by event type', () => {
+    const logs = [
+      makeLog({ id: 'a', event_type: 'task_completed', description: 'Task done' }),
+      makeLog({ id: 'b', event_type: 'pr_created', description: 'PR opened' }),
+    ]
+    render(<GlobalActivityFeed initialLogs={logs} agents={AGENTS} />)
+    fireEvent.click(screen.getByRole('button', { name: /pr created/i }))
+    expect(screen.getByText('PR opened')).toBeInTheDocument()
+    expect(screen.queryByText('Task done')).not.toBeInTheDocument()
+  })
+
+  it('shows only 20 items when more than 20 logs exist', () => {
+    render(<GlobalActivityFeed initialLogs={makeLogs(25)} agents={AGENTS} />)
+    expect(screen.getAllByRole('listitem')).toHaveLength(20)
+  })
+
+  it('shows "Load more" button when more than 20 logs', () => {
+    render(<GlobalActivityFeed initialLogs={makeLogs(25)} agents={AGENTS} />)
+    expect(screen.getByRole('button', { name: /load more/i })).toBeInTheDocument()
+  })
+
+  it('does not show "Load more" when 20 or fewer logs', () => {
+    render(<GlobalActivityFeed initialLogs={makeLogs(20)} agents={AGENTS} />)
+    expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument()
+  })
+
+  it('clicking "Load more" reveals additional items', () => {
+    render(<GlobalActivityFeed initialLogs={makeLogs(25)} agents={AGENTS} />)
+    fireEvent.click(screen.getByRole('button', { name: /load more/i }))
+    expect(screen.getAllByRole('listitem')).toHaveLength(25)
+  })
+
+  it('does not show agent link when agents is null', () => {
+    render(<GlobalActivityFeed initialLogs={[makeLog({ agents: null })]} agents={AGENTS} />)
+    expect(screen.queryByRole('link', { name: /ted openclaw/i })).not.toBeInTheDocument()
+  })
+
+  it('shows event count', () => {
+    render(<GlobalActivityFeed initialLogs={[makeLog({ id: 'a' }), makeLog({ id: 'b' })]} agents={AGENTS} />)
+    expect(screen.getByText('2 events')).toBeInTheDocument()
+  })
+
+  it('shows singular "event" when count is 1', () => {
+    render(<GlobalActivityFeed initialLogs={[makeLog()]} agents={AGENTS} />)
+    expect(screen.getByText('1 event')).toBeInTheDocument()
+  })
+
+  it('resets page when event type filter changes', () => {
+    const logs = [
+      ...makeLogs(21, 'task_completed'),
+      makeLog({ id: 'pr-1', event_type: 'pr_created', description: 'A PR was created' }),
+    ]
+    render(<GlobalActivityFeed initialLogs={logs} agents={AGENTS} />)
+    fireEvent.click(screen.getByRole('button', { name: /load more/i }))
+    fireEvent.click(screen.getByRole('button', { name: /pr created/i }))
+    expect(screen.getByText('A PR was created')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument()
+  })
+
+  it('shows "No activity found" when filter has no matches', () => {
+    render(<GlobalActivityFeed initialLogs={[makeLog({ event_type: 'task_completed' })]} agents={AGENTS} />)
+    fireEvent.click(screen.getByRole('button', { name: /pr created/i }))
+    expect(screen.getByText(/no activity found/i)).toBeInTheDocument()
+  })
+})

--- a/src/components/activity/__tests__/global-activity-feed.test.tsx
+++ b/src/components/activity/__tests__/global-activity-feed.test.tsx
@@ -51,9 +51,10 @@ describe('GlobalActivityFeed', () => {
     expect(screen.getByText('Deployed to Vercel')).toBeInTheDocument()
   })
 
-  it('renders event type badge', () => {
+  it('renders event type badge in the log entry', () => {
     render(<GlobalActivityFeed initialLogs={[makeLog({ event_type: 'task_completed' })]} agents={AGENTS} />)
-    expect(screen.getByText('Task Completed')).toBeInTheDocument()
+    const listItem = screen.getByRole('listitem')
+    expect(listItem).toHaveTextContent('Task Completed')
   })
 
   it('renders agent name linked to profile', () => {

--- a/src/components/activity/global-activity-feed.tsx
+++ b/src/components/activity/global-activity-feed.tsx
@@ -114,7 +114,7 @@ export function GlobalActivityFeed({ initialLogs, agents }: GlobalActivityFeedPr
                     : 'bg-secondary text-secondary-foreground hover:bg-secondary/80'
                 )}
               >
-                {type === 'all' ? 'All' : formatEventType(type).toLowerCase()}
+                {type === 'all' ? 'All' : formatEventType(type)}
               </button>
             ))}
           </div>

--- a/src/components/activity/global-activity-feed.tsx
+++ b/src/components/activity/global-activity-feed.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { cn } from '@/lib/utils'
@@ -10,7 +10,6 @@ import {
   type GlobalActivityLog,
   type DateRangeFilter,
 } from '@/lib/global-activity-utils'
-import type { Agent } from '@/types/agent'
 
 const PAGE_SIZE = 20
 
@@ -30,9 +29,14 @@ const DATE_RANGE_OPTIONS: { value: DateRangeFilter; label: string }[] = [
   { value: '30d', label: '30 days' },
 ]
 
+interface AgentOption {
+  id: string
+  name: string
+}
+
 interface GlobalActivityFeedProps {
   initialLogs: GlobalActivityLog[]
-  agents: Agent[]
+  agents: AgentOption[]
 }
 
 export function GlobalActivityFeed({ initialLogs, agents }: GlobalActivityFeedProps) {
@@ -50,11 +54,14 @@ export function GlobalActivityFeed({ initialLogs, agents }: GlobalActivityFeedPr
     return () => clearInterval(interval)
   }, [router])
 
-  const filtered = filterGlobalLogs(initialLogs, {
-    agentId: agentFilter,
-    eventType: eventTypeFilter,
-    dateRange: dateRangeFilter,
-  })
+  const filtered = useMemo(
+    () => filterGlobalLogs(initialLogs, {
+      agentId: agentFilter,
+      eventType: eventTypeFilter,
+      dateRange: dateRangeFilter,
+    }),
+    [initialLogs, agentFilter, eventTypeFilter, dateRangeFilter]
+  )
 
   const visible = filtered.slice(0, page * PAGE_SIZE)
   const hasMore = visible.length < filtered.length

--- a/src/components/activity/global-activity-feed.tsx
+++ b/src/components/activity/global-activity-feed.tsx
@@ -36,23 +36,11 @@ interface GlobalActivityFeedProps {
 }
 
 export function GlobalActivityFeed({ initialLogs, agents }: GlobalActivityFeedProps) {
-  const [logs, setLogs] = useState<GlobalActivityLog[]>(initialLogs)
   const [agentFilter, setAgentFilter] = useState('all')
   const [eventTypeFilter, setEventTypeFilter] = useState('all')
   const [dateRangeFilter, setDateRangeFilter] = useState<DateRangeFilter>('all')
   const [page, setPage] = useState(1)
   const router = useRouter()
-
-  // Merge new logs when server component re-renders with fresh data
-  useEffect(() => {
-    if (initialLogs.length === 0) return
-    setLogs((prev) => {
-      const existingIds = new Set(prev.map((l) => l.id))
-      const newLogs = initialLogs.filter((l) => !existingIds.has(l.id))
-      if (newLogs.length === 0) return prev
-      return [...newLogs, ...prev]
-    })
-  }, [initialLogs])
 
   // Auto-refresh every 30 seconds to pick up new activity
   useEffect(() => {
@@ -62,7 +50,7 @@ export function GlobalActivityFeed({ initialLogs, agents }: GlobalActivityFeedPr
     return () => clearInterval(interval)
   }, [router])
 
-  const filtered = filterGlobalLogs(logs, {
+  const filtered = filterGlobalLogs(initialLogs, {
     agentId: agentFilter,
     eventType: eventTypeFilter,
     dateRange: dateRangeFilter,

--- a/src/components/activity/global-activity-feed.tsx
+++ b/src/components/activity/global-activity-feed.tsx
@@ -1,0 +1,213 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { cn } from '@/lib/utils'
+import { formatEventType, getEventTypeBadgeColor } from '@/lib/activity-utils'
+import {
+  filterGlobalLogs,
+  type GlobalActivityLog,
+  type DateRangeFilter,
+} from '@/lib/global-activity-utils'
+import type { Agent } from '@/types/agent'
+
+const PAGE_SIZE = 20
+
+const EVENT_TYPE_OPTIONS = [
+  'all',
+  'task_started',
+  'task_completed',
+  'pr_created',
+  'issue_opened',
+  'deployment',
+]
+
+const DATE_RANGE_OPTIONS: { value: DateRangeFilter; label: string }[] = [
+  { value: 'all', label: 'All time' },
+  { value: 'today', label: 'Today' },
+  { value: '7d', label: '7 days' },
+  { value: '30d', label: '30 days' },
+]
+
+interface GlobalActivityFeedProps {
+  initialLogs: GlobalActivityLog[]
+  agents: Agent[]
+}
+
+export function GlobalActivityFeed({ initialLogs, agents }: GlobalActivityFeedProps) {
+  const [logs, setLogs] = useState<GlobalActivityLog[]>(initialLogs)
+  const [agentFilter, setAgentFilter] = useState('all')
+  const [eventTypeFilter, setEventTypeFilter] = useState('all')
+  const [dateRangeFilter, setDateRangeFilter] = useState<DateRangeFilter>('all')
+  const [page, setPage] = useState(1)
+  const router = useRouter()
+
+  // Merge new logs when server component re-renders with fresh data
+  useEffect(() => {
+    if (initialLogs.length === 0) return
+    setLogs((prev) => {
+      const existingIds = new Set(prev.map((l) => l.id))
+      const newLogs = initialLogs.filter((l) => !existingIds.has(l.id))
+      if (newLogs.length === 0) return prev
+      return [...newLogs, ...prev]
+    })
+  }, [initialLogs])
+
+  // Auto-refresh every 30 seconds to pick up new activity
+  useEffect(() => {
+    const interval = setInterval(() => {
+      router.refresh()
+    }, 30_000)
+    return () => clearInterval(interval)
+  }, [router])
+
+  const filtered = filterGlobalLogs(logs, {
+    agentId: agentFilter,
+    eventType: eventTypeFilter,
+    dateRange: dateRangeFilter,
+  })
+
+  const visible = filtered.slice(0, page * PAGE_SIZE)
+  const hasMore = visible.length < filtered.length
+
+  function handleAgentChange(agentId: string) {
+    setAgentFilter(agentId)
+    setPage(1)
+  }
+
+  function handleEventTypeChange(type: string) {
+    setEventTypeFilter(type)
+    setPage(1)
+  }
+
+  function handleDateRangeChange(range: DateRangeFilter) {
+    setDateRangeFilter(range)
+    setPage(1)
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Filters */}
+      <div className="flex flex-col gap-3 rounded-lg border border-border bg-card p-4">
+        {/* Agent filter */}
+        <div className="flex items-center gap-2">
+          <label htmlFor="agent-filter" className="text-xs font-medium text-muted-foreground w-14 shrink-0">
+            Agent
+          </label>
+          <select
+            id="agent-filter"
+            value={agentFilter}
+            onChange={(e) => handleAgentChange(e.target.value)}
+            className="rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground"
+          >
+            <option value="all">All agents</option>
+            {agents.map((a) => (
+              <option key={a.id} value={a.id}>
+                {a.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Event type filter */}
+        <div className="flex items-start gap-2">
+          <span className="text-xs font-medium text-muted-foreground w-14 shrink-0 pt-1">Event</span>
+          <div className="flex flex-wrap gap-1" role="group" aria-label="Filter by event type">
+            {EVENT_TYPE_OPTIONS.map((type) => (
+              <button
+                key={type}
+                onClick={() => handleEventTypeChange(type)}
+                aria-pressed={eventTypeFilter === type}
+                className={cn(
+                  'rounded-full px-3 py-1 text-xs font-medium transition-colors',
+                  eventTypeFilter === type
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-secondary text-secondary-foreground hover:bg-secondary/80'
+                )}
+              >
+                {type === 'all' ? 'All' : formatEventType(type).toLowerCase()}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Date range filter */}
+        <div className="flex items-start gap-2">
+          <span className="text-xs font-medium text-muted-foreground w-14 shrink-0 pt-1">Period</span>
+          <div className="flex flex-wrap gap-1" role="group" aria-label="Filter by date range">
+            {DATE_RANGE_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                onClick={() => handleDateRangeChange(opt.value)}
+                aria-pressed={dateRangeFilter === opt.value}
+                className={cn(
+                  'rounded-full px-3 py-1 text-xs font-medium transition-colors',
+                  dateRangeFilter === opt.value
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-secondary text-secondary-foreground hover:bg-secondary/80'
+                )}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Result count */}
+      <p className="text-xs text-muted-foreground">
+        {filtered.length} {filtered.length === 1 ? 'event' : 'events'}
+      </p>
+
+      {/* Log entries */}
+      {visible.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-4">No activity found.</p>
+      ) : (
+        <ol className="space-y-3">
+          {visible.map((log) => (
+            <li
+              key={log.id}
+              className="flex gap-3 rounded-lg border border-border bg-card p-3 text-sm"
+            >
+              <div className="flex flex-col gap-1 min-w-0 flex-1">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span
+                    className={cn(
+                      'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+                      getEventTypeBadgeColor(log.event_type)
+                    )}
+                  >
+                    {formatEventType(log.event_type)}
+                  </span>
+                  {log.agents && (
+                    <Link
+                      href={`/agents/${log.agents.id}`}
+                      className="text-xs font-medium text-foreground hover:underline"
+                    >
+                      {log.agents.name}
+                    </Link>
+                  )}
+                  <time dateTime={log.created_at} className="text-xs text-muted-foreground">
+                    {new Date(log.created_at).toLocaleString()}
+                  </time>
+                </div>
+                <p className="text-foreground">{log.description}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+
+      {/* Load more */}
+      {hasMore && (
+        <button
+          onClick={() => setPage((p) => p + 1)}
+          className="w-full rounded-md border border-border py-2 text-sm text-muted-foreground hover:bg-accent transition-colors"
+        >
+          Load more ({filtered.length - visible.length} remaining)
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/components/activity/global-activity-feed.tsx
+++ b/src/components/activity/global-activity-feed.tsx
@@ -107,6 +107,7 @@ export function GlobalActivityFeed({ initialLogs, agents }: GlobalActivityFeedPr
                 key={type}
                 onClick={() => handleEventTypeChange(type)}
                 aria-pressed={eventTypeFilter === type}
+                aria-label={type === 'all' ? 'All' : formatEventType(type)}
                 className={cn(
                   'rounded-full px-3 py-1 text-xs font-medium transition-colors',
                   eventTypeFilter === type
@@ -114,7 +115,7 @@ export function GlobalActivityFeed({ initialLogs, agents }: GlobalActivityFeedPr
                     : 'bg-secondary text-secondary-foreground hover:bg-secondary/80'
                 )}
               >
-                {type === 'all' ? 'All' : formatEventType(type)}
+                {type === 'all' ? 'All' : type.replace(/_/g, ' ')}
               </button>
             ))}
           </div>

--- a/src/lib/__tests__/global-activity-utils.test.ts
+++ b/src/lib/__tests__/global-activity-utils.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import {
+  filterGlobalLogs,
+  getDateRangeStart,
+  type GlobalActivityLog,
+} from '../global-activity-utils'
+
+function makeGlobalLog(overrides: Partial<GlobalActivityLog> = {}): GlobalActivityLog {
+  return {
+    id: 'log-1',
+    agent_id: 'agent-1',
+    event_type: 'task_completed',
+    description: 'Done',
+    metadata: null,
+    created_at: '2026-03-15T10:00:00Z',
+    agents: { id: 'agent-1', name: 'Ted', avatar_url: null },
+    ...overrides,
+  }
+}
+
+describe('filterGlobalLogs', () => {
+  it('returns all logs when all filters are "all"', () => {
+    const logs = [
+      makeGlobalLog({ id: 'a', agent_id: 'agent-1' }),
+      makeGlobalLog({ id: 'b', agent_id: 'agent-2' }),
+    ]
+    const result = filterGlobalLogs(logs, { agentId: 'all', eventType: 'all', dateRange: 'all' })
+    expect(result).toHaveLength(2)
+  })
+
+  it('filters by agentId', () => {
+    const logs = [
+      makeGlobalLog({ id: 'a', agent_id: 'agent-1' }),
+      makeGlobalLog({ id: 'b', agent_id: 'agent-2' }),
+    ]
+    const result = filterGlobalLogs(logs, { agentId: 'agent-1', eventType: 'all', dateRange: 'all' })
+    expect(result).toHaveLength(1)
+    expect(result[0].agent_id).toBe('agent-1')
+  })
+
+  it('filters by eventType', () => {
+    const logs = [
+      makeGlobalLog({ id: 'a', event_type: 'task_completed' }),
+      makeGlobalLog({ id: 'b', event_type: 'pr_created' }),
+    ]
+    const result = filterGlobalLogs(logs, { agentId: 'all', eventType: 'pr_created', dateRange: 'all' })
+    expect(result).toHaveLength(1)
+    expect(result[0].event_type).toBe('pr_created')
+  })
+
+  it('filters out logs before dateRange start for "today"', () => {
+    const todayStr = new Date().toISOString().split('T')[0]
+    const logs = [
+      makeGlobalLog({ id: 'a', created_at: `${todayStr}T10:00:00Z` }),
+      makeGlobalLog({ id: 'b', created_at: '2020-01-01T10:00:00Z' }),
+    ]
+    const result = filterGlobalLogs(logs, { agentId: 'all', eventType: 'all', dateRange: 'today' })
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('a')
+  })
+
+  it('combines agentId and eventType filters', () => {
+    const logs = [
+      makeGlobalLog({ id: 'a', agent_id: 'agent-1', event_type: 'task_completed' }),
+      makeGlobalLog({ id: 'b', agent_id: 'agent-1', event_type: 'pr_created' }),
+      makeGlobalLog({ id: 'c', agent_id: 'agent-2', event_type: 'task_completed' }),
+    ]
+    const result = filterGlobalLogs(logs, { agentId: 'agent-1', eventType: 'task_completed', dateRange: 'all' })
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('a')
+  })
+
+  it('returns empty array when no logs match', () => {
+    const result = filterGlobalLogs(
+      [makeGlobalLog({ agent_id: 'agent-1' })],
+      { agentId: 'agent-999', eventType: 'all', dateRange: 'all' }
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('handles empty logs array', () => {
+    const result = filterGlobalLogs([], { agentId: 'all', eventType: 'all', dateRange: 'all' })
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not mutate the original array', () => {
+    const logs = [
+      makeGlobalLog({ id: 'a', agent_id: 'agent-1' }),
+      makeGlobalLog({ id: 'b', agent_id: 'agent-2' }),
+    ]
+    const original = [...logs]
+    filterGlobalLogs(logs, { agentId: 'agent-1', eventType: 'all', dateRange: 'all' })
+    expect(logs).toEqual(original)
+  })
+})
+
+describe('getDateRangeStart', () => {
+  it('returns null for "all"', () => {
+    expect(getDateRangeStart('all')).toBeNull()
+  })
+
+  it('returns start of today for "today"', () => {
+    const start = getDateRangeStart('today')!
+    const now = new Date()
+    expect(start.toDateString()).toBe(now.toDateString())
+    expect(start.getHours()).toBe(0)
+    expect(start.getMinutes()).toBe(0)
+    expect(start.getSeconds()).toBe(0)
+  })
+
+  it('returns 7 days ago for "7d"', () => {
+    const start = getDateRangeStart('7d')!
+    const expected = new Date()
+    expected.setDate(expected.getDate() - 7)
+    expect(start.toDateString()).toBe(expected.toDateString())
+  })
+
+  it('returns 30 days ago for "30d"', () => {
+    const start = getDateRangeStart('30d')!
+    const expected = new Date()
+    expected.setDate(expected.getDate() - 30)
+    expect(start.toDateString()).toBe(expected.toDateString())
+  })
+})

--- a/src/lib/global-activity-utils.ts
+++ b/src/lib/global-activity-utils.ts
@@ -1,0 +1,38 @@
+import type { ActivityLog } from './activity-utils'
+
+export type GlobalActivityLog = ActivityLog & {
+  agents: { id: string; name: string; avatar_url: string | null } | null
+}
+
+export type DateRangeFilter = 'today' | '7d' | '30d' | 'all'
+
+export function getDateRangeStart(range: DateRangeFilter): Date | null {
+  if (range === 'all') return null
+
+  const now = new Date()
+
+  if (range === 'today') {
+    const start = new Date(now)
+    start.setHours(0, 0, 0, 0)
+    return start
+  }
+
+  const days = range === '7d' ? 7 : 30
+  const start = new Date(now)
+  start.setDate(start.getDate() - days)
+  return start
+}
+
+export function filterGlobalLogs(
+  logs: GlobalActivityLog[],
+  opts: { agentId: string; eventType: string; dateRange: DateRangeFilter }
+): GlobalActivityLog[] {
+  const start = getDateRangeStart(opts.dateRange)
+
+  return logs.filter((log) => {
+    if (opts.agentId !== 'all' && log.agent_id !== opts.agentId) return false
+    if (opts.eventType !== 'all' && log.event_type !== opts.eventType) return false
+    if (start && new Date(log.created_at) < start) return false
+    return true
+  })
+}


### PR DESCRIPTION
## Summary
- Adds a global activity feed page at `/activity` showing events across all agents
- Supports filtering by event type (commit, PR, deploy, error, etc.)
- Shows activity in reverse chronological order with rich event details

## Changes
- `src/app/activity/page.tsx` — Global activity feed page
- `src/components/activity/global-activity-feed.tsx` — Feed component with event type filters
- `src/lib/activity-utils.ts` — Utility functions for activity data
- `src/lib/global-activity-utils.ts` — Cross-agent activity aggregation
- Tests for all new components and utilities (31 new tests)

## Test plan
- [x] 31 new tests added for activity components and utils
- [x] All 217 existing tests continue to pass
- [x] Lint: passed
- [x] Typecheck: passed
- [x] Developed in isolated git worktree to avoid branch conflicts

Closes #7