### PR TITLE
Global activity feed page

### DIFF
--- a/src/app/activity/__tests__/page.test.tsx
+++ b/src/app/activity/__tests__/page.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+// Mock next/headers (used by supabase server client)
+vi.mock('next/headers', () => ({
+  cookies: () => ({
+    getAll: () => [],
+    set: () => {},
+  }),
+}))
+
+// Mock the supabase server client
+const mockSelect = vi.fn()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn().mockResolvedValue({
+    from: vi.fn((table: string) => {
+      if (table === 'agent_activity_logs') {
+        return {
+          select: mockSelect,
+        }
+      }
+      if (table === 'agents') {
+        return {
+          select: mockSelect,
+        }
+      }
+      return { select: mockSelect }
+    }),
+  }),
+}))
+
+import ActivityPage from '../page'
+
+const SAMPLE_LOGS = [
+  {
+    id: 'log-1',
+    agent_id: 'agent-1',
+    event_type: 'task_completed',
+    description: 'Finished a task',
+    metadata: null,
+    created_at: '2026-03-15T10:00:00Z',
+    agents: { id: 'agent-1', name: 'Scout', avatar_url: null },
+  },
+]
+
+const SAMPLE_AGENTS = [
+  {
+    id: 'agent-1',
+    name: 'Scout',
+    type: 'scout',
+    role: 'worker',
+    description: 'Test agent',
+    systems: [],
+    interaction_guide: '',
+    avatar_url: null,
+    status: 'active',
+    current_task: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('ActivityPage', () => {
+  it('renders the page heading', async () => {
+    // Setup mocks to return data
+    const { createClient } = await import('@/lib/supabase/server')
+    ;(createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      from: (table: string) => {
+        if (table === 'agent_activity_logs') {
+          return {
+            select: () => ({
+              order: () => ({
+                limit: () => Promise.resolve({ data: SAMPLE_LOGS, error: null }),
+              }),
+            }),
+          }
+        }
+        // agents table
+        return {
+          select: () => ({
+            order: () => Promise.resolve({ data: SAMPLE_AGENTS, error: null }),
+          }),
+        }
+      },
+    })
+
+    const Page = await ActivityPage()
+    render(Page)
+
+    expect(screen.getByRole('heading', { name: /activity/i })).toBeInTheDocument()
+  })
+
+  it('renders GlobalActivityFeed with logs', async () => {
+    const { createClient } = await import('@/lib/supabase/server')
+    ;(createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      from: (table: string) => {
+        if (table === 'agent_activity_logs') {
+          return {
+            select: () => ({
+              order: () => ({
+                limit: () => Promise.resolve({ data: SAMPLE_LOGS, error: null }),
+              }),
+            }),
+          }
+        }
+        return {
+          select: () => ({
+            order: () => Promise.resolve({ data: SAMPLE_AGENTS, error: null }),
+          }),
+        }
+      },
+    })
+
+    const Page = await ActivityPage()
+    render(Page)
+
+    expect(screen.getByText('Finished a task')).toBeInTheDocument()
+  })
+
+  it('renders with empty logs on Supabase error', async () => {
+    const { createClient } = await import('@/lib/supabase/server')
+    ;(createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      from: () => ({
+        select: () => ({
+          order: () => ({
+            limit: () => Promise.resolve({ data: null, error: { message: 'DB error' } }),
+          }),
+        }),
+      }),
+    })
+
+    const Page = await ActivityPage()
+    render(Page)
+
+    expect(screen.getByText(/no activity found/i)).toBeInTheDocument()
+  })
+})

--- a/src/app/activity/page.tsx
+++ b/src/app/activity/page.tsx
@@ -1,0 +1,41 @@
+import { createClient } from '@/lib/supabase/server'
+import { GlobalActivityFeed } from '@/components/activity/global-activity-feed'
+import type { GlobalActivityLog } from '@/lib/global-activity-utils'
+import type { Agent } from '@/types/agent'
+
+export const dynamic = 'force-dynamic'
+
+export default async function ActivityPage() {
+  const supabase = await createClient()
+
+  const [logsResult, agentsResult] = await Promise.all([
+    supabase
+      .from('agent_activity_logs')
+      .select('*, agents(id, name, avatar_url)')
+      .order('created_at', { ascending: false })
+      .limit(500),
+    supabase.from('agents').select('*').order('name'),
+  ])
+
+  if (logsResult.error) {
+    console.error('Failed to fetch activity logs:', logsResult.error.message)
+  }
+  if (agentsResult.error) {
+    console.error('Failed to fetch agents:', agentsResult.error.message)
+  }
+
+  const logs = (logsResult.data ?? []) as GlobalActivityLog[]
+  const agents = (agentsResult.data ?? []) as Agent[]
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold text-foreground">Activity</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Chronological stream of all agent actions across all projects.
+        </p>
+      </div>
+      <GlobalActivityFeed initialLogs={logs} agents={agents} />
+    </div>
+  )
+}

--- a/src/components/activity/global-activity-feed.tsx
+++ b/src/components/activity/global-activity-feed.tsx
@@ -1,0 +1,205 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { cn } from '@/lib/utils'
+import { formatEventType, getEventTypeBadgeColor } from '@/lib/activity-utils'
+import type { GlobalActivityLog } from '@/lib/global-activity-utils'
+import type { Agent } from '@/types/agent'
+
+const PAGE_SIZE = 20
+const REFRESH_INTERVAL_MS = 30_000
+
+const EVENT_TYPE_OPTIONS = [
+  'all',
+  'task_started',
+  'task_completed',
+  'pr_created',
+  'issue_opened',
+  'deployment',
+]
+
+interface GlobalActivityFeedProps {
+  initialLogs: GlobalActivityLog[]
+  agents: Agent[]
+}
+
+export function GlobalActivityFeed({ initialLogs, agents }: GlobalActivityFeedProps) {
+  const [logs, setLogs] = useState<GlobalActivityLog[]>(initialLogs)
+  const [filterAgent, setFilterAgent] = useState<string>('all')
+  const [filterType, setFilterType] = useState<string>('all')
+  const [filterDateFrom, setFilterDateFrom] = useState<string>('')
+  const [filterDateTo, setFilterDateTo] = useState<string>('')
+  const [page, setPage] = useState(1)
+
+  const applyFilters = useCallback(
+    (source: GlobalActivityLog[]) => {
+      return source.filter((log) => {
+        if (filterAgent !== 'all' && log.agent_id !== filterAgent) return false
+        if (filterType !== 'all' && log.event_type !== filterType) return false
+        if (filterDateFrom) {
+          const from = new Date(filterDateFrom)
+          if (new Date(log.created_at) < from) return false
+        }
+        if (filterDateTo) {
+          const to = new Date(filterDateTo)
+          to.setHours(23, 59, 59, 999)
+          if (new Date(log.created_at) > to) return false
+        }
+        return true
+      })
+    },
+    [filterAgent, filterType, filterDateFrom, filterDateTo]
+  )
+
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      try {
+        const res = await fetch('/api/activity')
+        if (!res.ok) return
+        const data: GlobalActivityLog[] = await res.json()
+        setLogs(data)
+      } catch {
+        // silently ignore refresh errors
+      }
+    }, REFRESH_INTERVAL_MS)
+    return () => clearInterval(interval)
+  }, [])
+
+  function resetPage() {
+    setPage(1)
+  }
+
+  const filtered = applyFilters(logs)
+  const visible = filtered.slice(0, page * PAGE_SIZE)
+  const hasMore = visible.length < filtered.length
+
+  return (
+    <div className="space-y-4">
+      {/* Filters */}
+      <div className="flex flex-col gap-3">
+        {/* Event type filter */}
+        <div className="flex flex-wrap gap-2" role="group" aria-label="Filter by event type">
+          {EVENT_TYPE_OPTIONS.map((type) => (
+            <button
+              key={type}
+              onClick={() => {
+                setFilterType(type)
+                resetPage()
+              }}
+              aria-pressed={filterType === type}
+              className={cn(
+                'rounded-full px-3 py-1 text-xs font-medium transition-colors',
+                filterType === type
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-secondary text-secondary-foreground hover:bg-secondary/80'
+              )}
+            >
+              {type === 'all' ? 'All Events' : formatEventType(type)}
+            </button>
+          ))}
+        </div>
+
+        {/* Agent + date filters */}
+        <div className="flex flex-wrap gap-3 items-center">
+          <select
+            value={filterAgent}
+            onChange={(e) => {
+              setFilterAgent(e.target.value)
+              resetPage()
+            }}
+            aria-label="Filter by agent"
+            className="rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground"
+          >
+            <option value="all">All Agents</option>
+            {agents.map((agent) => (
+              <option key={agent.id} value={agent.id}>
+                {agent.name}
+              </option>
+            ))}
+          </select>
+
+          <div className="flex items-center gap-2">
+            <label className="text-xs text-muted-foreground" htmlFor="date-from">
+              From
+            </label>
+            <input
+              id="date-from"
+              type="date"
+              value={filterDateFrom}
+              onChange={(e) => {
+                setFilterDateFrom(e.target.value)
+                resetPage()
+              }}
+              className="rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground"
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <label className="text-xs text-muted-foreground" htmlFor="date-to">
+              To
+            </label>
+            <input
+              id="date-to"
+              type="date"
+              value={filterDateTo}
+              onChange={(e) => {
+                setFilterDateTo(e.target.value)
+                resetPage()
+              }}
+              className="rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Log entries */}
+      {visible.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-4">No activity found.</p>
+      ) : (
+        <ol className="space-y-3">
+          {visible.map((log) => (
+            <li
+              key={log.id}
+              className="flex gap-3 rounded-lg border border-border bg-card p-3 text-sm"
+            >
+              <div className="flex flex-col gap-1 min-w-0 flex-1">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span
+                    className={cn(
+                      'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+                      getEventTypeBadgeColor(log.event_type)
+                    )}
+                  >
+                    {formatEventType(log.event_type)}
+                  </span>
+                  {log.agents && (
+                    <span className="text-xs font-medium text-foreground">
+                      {log.agents.name}
+                    </span>
+                  )}
+                  <time
+                    dateTime={log.created_at}
+                    className="text-xs text-muted-foreground"
+                  >
+                    {new Date(log.created_at).toLocaleString()}
+                  </time>
+                </div>
+                <p className="text-foreground">{log.description}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+
+      {/* Load more */}
+      {hasMore && (
+        <button
+          onClick={() => setPage((p) => p + 1)}
+          className="w-full rounded-md border border-border py-2 text-sm text-muted-foreground hover:bg-accent transition-colors"
+        >
+          Load more ({filtered.length - visible.length} remaining)
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/lib/global-activity-utils.ts
+++ b/src/lib/global-activity-utils.ts
@@ -1,0 +1,9 @@
+import type { ActivityLog } from '@/lib/activity-utils'
+
+export interface GlobalActivityLog extends ActivityLog {
+  agents: {
+    id: string
+    name: string
+    avatar_url: string | null
+  } | null
+}


### PR DESCRIPTION
## Summary
- Adds `/activity` route with a chronological activity feed across all agents
- Implements filtering by agent, event type, and date range
- Adds \"Load more\" pagination (20 items per page)
- Auto-refreshes every 30 seconds via `/api/activity` polling

## Changes
- `src/app/activity/page.tsx` — Server component that fetches logs + agents from Supabase and renders the feed
- `src/components/activity/global-activity-feed.tsx` — Client component with filter controls, paginated list, and auto-refresh
- `src/lib/global-activity-utils.ts` — `GlobalActivityLog` type extending `ActivityLog` with joined agent data
- `src/app/activity/__tests__/page.test.tsx` — 3 Vitest tests covering render, data display, and error fallback

## Test Results
- 234 tests passed, 0 failed
- Lint: clean
- Typecheck: clean
- Build: success (`/activity` renders as ƒ Dynamic)

## Closes
Closes #7

---
Implemented by weppneragents-droid via Dennis Agent System